### PR TITLE
Fixed deprecated class reference in UpdateViewBuilder

### DIFF
--- a/src/lib/View/UserSettings/UpdateViewBuilder.php
+++ b/src/lib/View/UserSettings/UpdateViewBuilder.php
@@ -44,7 +44,7 @@ class UpdateViewBuilder implements ViewBuilder
      */
     public function matches($argument): bool
     {
-        return 'EzSystems\EzPlatformUserBundle\Controller\UserSettingsController::updateAction' === $argument;
+        return 'Ibexa\Bundle\User\Controller\UserSettingsController::updateAction' === $argument;
     }
 
     /**


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  -
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | ?
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Fixed the following error

```
Cannot autowire argument $view of "Ibexa\Bundle\User\Controller\UserSettingsController::updateAction()": it references class "Ibexa\User\View\UserSettings\UpdateView" but no such service exists.
```

while opening User Settings in admin-ui.


#### Checklist:
- [ ] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
