### PR TITLE
Made the user registration content type configurable

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
@@ -60,7 +60,8 @@ class UserRegistration extends AbstractParser
             $contextualizer->setContextualParameter(
                 'user_registration.user_type_identifier',
                 $currentScope,
-                $settings['user_type_identifier']);
+                $settings['user_type_identifier']
+            );
         }
 
         if (!empty($settings['group_id'])) {

--- a/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
@@ -25,6 +25,10 @@ class UserRegistration extends AbstractParser
             ->arrayNode('user_registration')
                 ->info('User registration configuration')
                 ->children()
+                    ->scalarNode('user_type_identifier')
+                        ->info('Content type identifier used for registration.')
+                        ->defaultValue('user')
+                    ->end()
                     ->scalarNode('group_id')
                         ->info('Content id of the user group where users who register are created.')
                         ->defaultValue(11)
@@ -51,6 +55,13 @@ class UserRegistration extends AbstractParser
         }
 
         $settings = $scopeSettings['user_registration'];
+
+        if (!empty($settings['user_type_identifier'])) {
+            $contextualizer->setContextualParameter(
+                'user_registration.user_type_identifier',
+                $currentScope,
+                $settings['user_type_identifier']);
+        }
 
         if (!empty($settings['group_id'])) {
             $contextualizer->setContextualParameter(

--- a/src/bundle/Resources/config/ezplatform_default_settings.yaml
+++ b/src/bundle/Resources/config/ezplatform_default_settings.yaml
@@ -13,6 +13,7 @@ parameters:
 
     # Registration
     ezsettings.default.user_registration.group_id: 11
+    ezsettings.default.user_registration.user_type_identifier: "user"
     ezsettings.default.user_registration.templates.form: "@@IbexaContentForms/Content/content_edit.html.twig"
     ezsettings.default.user_registration.templates.confirmation: "@@IbexaUser/register/register_confirmation.html.twig"
 

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -34,9 +34,7 @@ services:
 
     Ibexa\User\ConfigResolver\ConfigurableRegistrationGroupLoader: ~
 
-    Ibexa\User\ConfigResolver\ConfigurableRegistrationContentTypeLoader:
-        calls:
-            - [setParam, ["contentTypeIdentifier", "%ezplatform.user.content_type_identifier%"]]
+    Ibexa\User\ConfigResolver\ConfigurableRegistrationContentTypeLoader: ~
 
     # Default implementations
     Ibexa\User\ConfigResolver\RegistrationGroupLoader: '@Ibexa\User\ConfigResolver\ConfigurableRegistrationGroupLoader'

--- a/src/lib/ConfigResolver/ConfigurableRegistrationContentTypeLoader.php
+++ b/src/lib/ConfigResolver/ConfigurableRegistrationContentTypeLoader.php
@@ -8,18 +8,18 @@ declare(strict_types=1);
 
 namespace Ibexa\User\ConfigResolver;
 
-use eZ\Publish\API\Repository\Repository;
-use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Ibexa\Contracts\Core\Repository\Repository;
+use Ibexa\Core\MVC\ConfigResolverInterface;
 
 /**
  * Loads the registration content type from a configured, injected content type identifier.
  */
 class ConfigurableRegistrationContentTypeLoader implements RegistrationContentTypeLoader
 {
-    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    /** @var \Ibexa\Core\MVC\ConfigResolverInterface */
     private $configResolver;
 
-    /** @var \eZ\Publish\API\Repository\Repository */
+    /** @var \Ibexa\Contracts\Core\Repository\Repository */
     private $repository;
 
     public function __construct(ConfigResolverInterface $configResolver, Repository $repository)

--- a/src/lib/ConfigResolver/ConfigurableRegistrationContentTypeLoader.php
+++ b/src/lib/ConfigResolver/ConfigurableRegistrationContentTypeLoader.php
@@ -10,7 +10,6 @@ namespace Ibexa\User\ConfigResolver;
 
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Loads the registration content type from a configured, injected content type identifier.


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-XXXXX](https://jira.ez.no/browse/EZP-XXXXX) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes/no
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)


Makes the user content type used for registration configurable, like the destination group.

```yaml
ibexa:
  system:
    site:
      user_registration:

        # Content type identifier used for registration.
        user_type_identifier: "customer"

        # Content id of the user group where users who register are created.
        group_id:             11
```

#### Checklist:
- [ ] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
