### PR TITLE
IBX-2247: Sets proper content-type for user initials

### DIFF
--- a/src/bundle/Controller/DefaultProfileImageController.php
+++ b/src/bundle/Controller/DefaultProfileImageController.php
@@ -27,11 +27,14 @@ final class DefaultProfileImageController extends Controller
         $initials = substr($request->query->get('initials', ''), 0, 2);
         $colors = $this->getInitialsColors($initials);
 
+        $response = new Response();
+        $response->headers->set('content-type', 'image/svg+xml');
+
         return $this->render('@IbexaUser/profile_image/initials.svg.twig', [
             'initials' => $initials,
             'text' => $colors['text'],
             'background' => $colors['background'],
-        ]);
+        ], $response);
     }
 
     private function getInitialsColors(string $initials): array


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |    [IBX-2247](https://issues.ibexa.co/browse/IBX-2247)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Sets proper content-type for user initials

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
