### PR TITLE
IBX-1439: Dropped league/flysystem-memory dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
         "ibexa/http-cache": "~4.4.0@dev",
         "ibexa/fieldtype-richtext": "~4.4.0@dev",
         "ibexa/rest": "~4.4.0@dev",
-        "league/flysystem-memory": "^1.0",
         "symfony/proxy-manager-bridge": "^5.0",
         "friendsofphp/php-cs-fixer": "^3.0",
         "ibexa/code-style": "^1.0",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1439](https://issues.ibexa.co/browse/IBX-1439)
| **Requires**                            | ibexa/core#171
| **Type**                                   | feature
| **Target Ibexa version** | `v4.4`
| **BC breaks**                          | not for this package
| **CI build**                      | [3765925652](https://github.com/ibexa/user/actions/runs/3765925652), Behat failing due to dep. mismatch

~This PR bumps `league/flysystem-memory` dependency to use Flysystem v2.~ There are no direct usages of `flysystem-memory` library, however `ibexa/core` ~requires~ required this as dev dependency, so we either have to do it here as well or make it production dependency in `ibexa/core`.

```
PHP Fatal error:  Uncaught LogicException: Missing League\Flysystem\InMemory\InMemoryFilesystemAdapter class. Ensure that league/flysystem-memory package is installed as a dev dependency in /home/runner/work/user/user/vendor/ibexa/core/src/contracts/Test/IbexaTestKernel.php:213
```

**UPDATE:** after internal sync we've decided to move the dependency to Composer's `require` section in ibexa/core#171

### TODO
- [x] :exclamation: **REMOVE TMP COMMIT BEFORE MERGE** :exclamation:

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
