### PR TITLE
Manually wired Connection for InvitationGateway

### DIFF
--- a/src/bundle/Resources/config/services/invitation.yaml
+++ b/src/bundle/Resources/config/services/invitation.yaml
@@ -18,7 +18,10 @@ services:
             $mapper: '@Ibexa\User\Invitation\Persistence\Mapper'
             $gateway: '@Ibexa\User\Invitation\Persistence\DoctrineGateway'
 
-    Ibexa\User\Invitation\Persistence\DoctrineGateway: ~
+    Ibexa\User\Invitation\Persistence\DoctrineGateway:
+        arguments:
+            $connection: '@ibexa.persistence.connection'
+
     Ibexa\User\Invitation\MailSender: ~
     Ibexa\User\Invitation\Persistence\Mapper: ~
     Ibexa\User\Invitation\DomainMapper: ~


### PR DESCRIPTION
Behat failure: https://github.com/ibexa/commerce/actions/runs/4473234212/jobs/7860504781

```
    │  	[2023-03-20T22:40:09.084118+00:00] request.CRITICAL: Uncaught PHP Exception Doctrine\DBAL\Exception\ConnectionException: "An exception occurred in driver: 
SQLSTATE[HY000] [2002] Connection refused" at /var/www/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php line 112 {"exception":"[object] 
(Doctrine\\DBAL\\Exception\\ConnectionException(code: 0): 
An exception occurred in driver: SQLSTATE[HY000] [2002] 
Connection refused at /var/www/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:112)\n[previous exception] [object] (Doctrine\\DBAL\\Driver\\PDO\\Exception(code: 2002): 
SQLSTATE[HY000] [2002] Connection refused at /var/www/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDO/Exception.php:18)\n[previous exception] 
[object] (PDOException(code: 2002): SQLSTATE[HY000] [2002] 
Connection refused at /var/www/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:40)"} []
```

![obraz](https://user-images.githubusercontent.com/10993858/226549871-27617678-e7d9-4b4c-a6d0-a0a32ba96786.png)

Some Behat tests are running with broken default connection to detect when the Connection is wired in a wrong way (autowired) - https://github.com/ibexa/user/blob/main/src/lib/Invitation/Persistence/DoctrineGateway.php#L30-L33