### PR TITLE
Removed Acholi dialect from the list of available translations

### DIFF
--- a/src/lib/Form/ChoiceList/Loader/AvailableLocaleChoiceLoader.php
+++ b/src/lib/Form/ChoiceList/Loader/AvailableLocaleChoiceLoader.php
@@ -17,6 +17,10 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class AvailableLocaleChoiceLoader implements ChoiceLoaderInterface
 {
+    // Acholi dialect is used by In-Context translation
+    // and should not be present on the list of available translations.
+    private const EXCLUDED_TRANSLATIONS = ['ach'];
+
     /** @var \Symfony\Component\Validator\Validator\ValidatorInterface */
     private $validator;
 
@@ -47,8 +51,9 @@ class AvailableLocaleChoiceLoader implements ChoiceLoaderInterface
 
         $additionalTranslations = $this->configResolver->getParameter('user_preferences.additional_translations');
         $availableLocales = array_unique(array_merge($this->availableTranslations, $additionalTranslations));
+        $locales = array_diff($availableLocales, self::EXCLUDED_TRANSLATIONS);
 
-        foreach ($availableLocales as $locale) {
+        foreach ($locales as $locale) {
             if (0 === $this->validator->validate($locale, new Locale())->count()) {
                 $choices[Locales::getName($locale)] = $locale;
             }

--- a/tests/lib/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoaderTest.php
+++ b/tests/lib/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoaderTest.php
@@ -11,7 +11,6 @@ namespace Ibexa\Tests\User\Form\Type\ChoiceList\Loader;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\User\Form\ChoiceList\Loader\AvailableLocaleChoiceLoader;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Validator\Constraints\Locale;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -20,9 +19,6 @@ class AvailableLocaleChoiceLoaderTest extends TestCase
 {
     /** @var \Symfony\Component\Validator\Validator\ValidatorInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $validator;
-
-    /** @var \Symfony\Component\Validator\Constraints\Locale|\PHPUnit\Framework\MockObject\MockObject */
-    private $localeConstraint;
 
     /** @var \Symfony\Component\Validator\ConstraintViolationInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $constraintViolation;
@@ -34,7 +30,6 @@ class AvailableLocaleChoiceLoaderTest extends TestCase
     {
         parent::setUp();
 
-        $this->localeConstraint = $this->createMock(Locale::class);
         $this->validator = $this->createMock(ValidatorInterface::class);
         $this->constraintViolation = $this->createMock(ConstraintViolationInterface::class);
         $this->configResolver = $this->createMock(ConfigResolverInterface::class);
@@ -99,6 +94,13 @@ class AvailableLocaleChoiceLoaderTest extends TestCase
                     'English' => 'en',
                     'Norwegian Bokmål (Norway)' => 'nb_NO',
                     'German (Germany)' => 'de_DE',
+                ],
+            ],
+            'acholi_exlusion' => [
+                ['en', 'ach'],
+                [],
+                [
+                    'English' => 'en',
                 ],
             ],
         ];


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  N/A
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


Since In-context translations are toggled by a dedicated setting there is no need to have Acholi dialect on the list of available translations. This change will also prevent validation errors because Acholi is not a valid Locale 


#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
