### PR TITLE
Remove outdated config example

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/Security.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Security.php
@@ -14,15 +14,6 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 /**
  * Configuration parser for system security configuration.
- *
- * Example configuration:
- * ```yaml
- * ezpublish:
- *   system:
- *      default: # configuration per siteaccess or siteaccess group
- *          security:
- *              token_interval_spec: 'PT1H'
- * ```
  */
 class Security extends AbstractParser
 {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  N/A
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)

Just running tests before merge because paranoia.

NB: debug config isn't implemented for the user bundle.
```
php bin/console debug:config ibexa_user:
The extension with alias "ibexa_user" does not have its getConfiguration() method setup.
```
We have doc at https://doc.ibexa.co/en/latest/users/user_management/#changing-and-recovering-passwords