### PR TITLE
IBX-7276: Added deprecation notice for `ibexa_user_get_current` twig function

### DIFF
--- a/src/bundle/Twig/UserExtension.php
+++ b/src/bundle/Twig/UserExtension.php
@@ -18,7 +18,11 @@ final class UserExtension extends AbstractExtension
         return [
             new TwigFunction(
                 'ibexa_user_get_current',
-                [UserRuntime::class, 'getCurrentUser']
+                [UserRuntime::class, 'getCurrentUser'],
+                [
+                    'deprecated' => '4.6',
+                    'alternative' => 'ibexa_current_user',
+                ]
             ),
         ];
     }


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [IBX-7276](https://issues.ibexa.co/browse/IBX-7276) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ibexa/admin-ui/blob/main/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


As a new function was added to the `core` package there is a need to deprecate the existing one


#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
