### PR TITLE
IBX-7911: Replaced usage of magic getters for load subtree code paths

### DIFF
--- a/src/lib/Strategy/DefaultThumbnailStrategy.php
+++ b/src/lib/Strategy/DefaultThumbnailStrategy.php
@@ -57,8 +57,8 @@ final class DefaultThumbnailStrategy implements ThumbnailStrategy
         foreach ($this->initialsFieldDefIdentifiers as $identifier) {
             /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Field $field */
             foreach ($fields as $field) {
-                if ($field->fieldDefIdentifier === $identifier) {
-                    $initials .= substr((string)$field->value, 0, 1);
+                if ($field->getFieldDefinitionIdentifier() === $identifier) {
+                    $initials .= substr((string)$field->getValue(), 0, 1);
                 }
             }
         }

--- a/src/lib/UserSetting/UserSetting.php
+++ b/src/lib/UserSetting/UserSetting.php
@@ -11,10 +11,10 @@ namespace Ibexa\User\UserSetting;
 use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 
 /**
- * @property string $identifier @deprecated use {@see UserSetting::getIdentifier()} instead.
- * @property string $name @deprecated use {@see UserSetting::getName()} instead.
- * @property string $description @deprecated use {@see UserSetting::getDescription()} instead.
- * @property string $value @deprecated use {@see UserSetting::getValue()} instead.
+ * @property string $identifier @deprecated 4.6.7 accessing magic getter is deprecated and will be removed in 5.0.0. Use {@see UserSetting::getIdentifier()} instead.
+ * @property string $name @deprecated 4.6.7 accessing magic getter is deprecated and will be removed in 5.0.0. Use {@see UserSetting::getName()} instead.
+ * @property string $description @deprecated 4.6.7 accessing magic getter is deprecated and will be removed in 5.0.0. Use {@see UserSetting::getDescription()} instead.
+ * @property string $value @deprecated 4.6.7 accessing magic getter is deprecated and will be removed in 5.0.0. Use {@see UserSetting::getValue()} instead.
  */
 class UserSetting extends ValueObject
 {

--- a/src/lib/UserSetting/UserSetting.php
+++ b/src/lib/UserSetting/UserSetting.php
@@ -20,6 +20,7 @@ class UserSetting extends ValueObject
 {
     /** @var string */
     protected $identifier;
+
     /** @var string */
     protected $name;
 

--- a/src/lib/UserSetting/UserSetting.php
+++ b/src/lib/UserSetting/UserSetting.php
@@ -11,16 +11,15 @@ namespace Ibexa\User\UserSetting;
 use Ibexa\Contracts\Core\Repository\Values\ValueObject;
 
 /**
- * @property string $identifier
- * @property string $name
- * @property string $description
- * @property string $value
+ * @property string $identifier @deprecated use {@see UserSetting::getIdentifier()} instead.
+ * @property string $name @deprecated use {@see UserSetting::getName()} instead.
+ * @property string $description @deprecated use {@see UserSetting::getDescription()} instead.
+ * @property string $value @deprecated use {@see UserSetting::getValue()} instead.
  */
 class UserSetting extends ValueObject
 {
     /** @var string */
     protected $identifier;
-
     /** @var string */
     protected $name;
 
@@ -29,6 +28,26 @@ class UserSetting extends ValueObject
 
     /** @var string */
     protected $value;
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
 }
 
 class_alias(UserSetting::class, 'EzSystems\EzPlatformUser\UserSetting\UserSetting');


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7911](https://issues.ibexa.co/browse/IBX-7911)
| **Requires** | ibexa/core#347
| **Required by** | ibexa/admin-ui#1212
| **Type**                                   | bug
| **Target Ibexa version** | `v4.6`
| **BC breaks**                          | no

This PR replaces usages of magic getters with strict ones introduced via ibexa/core#347 and introduces strict getters for `UserSetting` Value Object, needed by ibexa/admin-ui#1212. See the ibexa/core PR for the reasoning behind this change.

The scope of the changes is limited to code paths executed when calling `ContentTreeController::loadSubreeAction` controller.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly.
- [ ] Asked for a review.