### PR TITLE
IBX-7862: Fixed user setting value

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -761,11 +761,6 @@ parameters:
 			path: src/lib/UserSetting/Setting/FullDateTimeFormat.php
 
 		-
-			message: "#^Method Ibexa\\\\User\\\\UserSetting\\\\Setting\\\\Language\\:\\:getDefaultValue\\(\\) should return string but returns string\\|false\\.$#"
-			count: 1
-			path: src/lib/UserSetting/Setting/Language.php
-
-		-
 			message: "#^Method Ibexa\\\\User\\\\UserSetting\\\\Setting\\\\ShortDateTimeFormat\\:\\:getDefaultValue\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: src/lib/UserSetting/Setting/ShortDateTimeFormat.php

--- a/src/lib/UserSetting/Setting/Language.php
+++ b/src/lib/UserSetting/Setting/Language.php
@@ -72,13 +72,16 @@ class Language implements ValueDefinitionInterface, FormMapperInterface
      */
     public function getDefaultValue(): string
     {
+        $defaultLocale = '';
         $preferredLocales = $this->userLanguagePreferenceProvider->getPreferredLocales();
 
         $list = $this->availableLocaleChoiceLoader->getChoiceList();
-        $commonLocales = array_intersect($list, $preferredLocales);
-        $locales = empty($commonLocales) ? $preferredLocales : $commonLocales;
+        $commonLocales = array_intersect($preferredLocales, $list);
+        if (!empty($commonLocales)) {
+            $defaultLocale = reset($commonLocales);
+        }
 
-        return reset($locales);
+        return $defaultLocale;
     }
 
     /**

--- a/src/lib/UserSetting/Setting/Language.php
+++ b/src/lib/UserSetting/Setting/Language.php
@@ -74,7 +74,11 @@ class Language implements ValueDefinitionInterface, FormMapperInterface
     {
         $preferredLocales = $this->userLanguagePreferenceProvider->getPreferredLocales();
 
-        return reset($preferredLocales);
+        $list = $this->availableLocaleChoiceLoader->getChoiceList();
+        $commonLocales = array_intersect($list, $preferredLocales);
+        $locales = empty($commonLocales) ? $preferredLocales : $commonLocales;
+
+        return reset($locales);
     }
 
     /**

--- a/tests/lib/UserSetting/Setting/LanguageTest.php
+++ b/tests/lib/UserSetting/Setting/LanguageTest.php
@@ -16,10 +16,10 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class LanguageTest extends TestCase
 {
-    /** @var \Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface&\PHPUnit\Framework\MockObject\MockObject */
     private UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider;
 
-    /** @var \Ibexa\User\Form\ChoiceList\Loader\AvailableLocaleChoiceLoader|\PHPUnit\Framework\MockObject\MockObject */
+    /** @var \Ibexa\User\Form\ChoiceList\Loader\AvailableLocaleChoiceLoader&\PHPUnit\Framework\MockObject\MockObject */
     private AvailableLocaleChoiceLoader $availableLocaleChoiceLoader;
 
     protected function setUp(): void
@@ -61,6 +61,7 @@ final class LanguageTest extends TestCase
     public function providerForDefaultValue(): iterable
     {
         yield 'intersection' => [['en_GB', 'en'], ['en', 'de', 'el', 'en_US'], 'en'];
-        yield 'preferred_locales' => [['en_GB', 'en'], ['de', 'el', 'en_US'], 'en_GB'];
+        yield 'no available locale' => [['en_GB', 'en'], ['de', 'el', 'en_US'], ''];
+        yield 'user preferred language priority' => [['en_GB', 'en', 'de'], ['de', 'en', 'el'], 'en'];
     }
 }

--- a/tests/lib/UserSetting/Setting/LanguageTest.php
+++ b/tests/lib/UserSetting/Setting/LanguageTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\User\UserSetting;
+
+use Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
+use Ibexa\User\Form\ChoiceList\Loader\AvailableLocaleChoiceLoader;
+use Ibexa\User\UserSetting\Setting\Language;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class LanguageTest extends TestCase
+{
+    /** @var \Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider;
+
+    /** @var \Ibexa\User\Form\ChoiceList\Loader\AvailableLocaleChoiceLoader|\PHPUnit\Framework\MockObject\MockObject */
+    private AvailableLocaleChoiceLoader $availableLocaleChoiceLoader;
+
+    protected function setUp(): void
+    {
+        $this->userLanguagePreferenceProvider = $this->createMock(
+            UserLanguagePreferenceProviderInterface::class
+        );
+        $this->availableLocaleChoiceLoader = $this->createMock(
+            AvailableLocaleChoiceLoader::class
+        );
+    }
+
+    /**
+     * @dataProvider providerForDefaultValue
+     *
+     * @param string[] $availableLocales
+     * @param string[] $preferredLocales
+     */
+    public function testGetDefaultValue(
+        array $preferredLocales,
+        array $availableLocales,
+        string $expectedDefaultValue
+    ): void {
+        $this->userLanguagePreferenceProvider->method('getPreferredLocales')->willReturn($preferredLocales);
+        $this->availableLocaleChoiceLoader->method('getChoiceList')->willReturn($availableLocales);
+
+        $language = new Language(
+            $this->createMock(TranslatorInterface::class),
+            $this->userLanguagePreferenceProvider,
+            $this->availableLocaleChoiceLoader,
+        );
+
+        self::assertSame($expectedDefaultValue, $language->getDefaultValue());
+    }
+
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public function providerForDefaultValue(): iterable
+    {
+        yield 'intersection' => [['en_GB', 'en'], ['en', 'de', 'el', 'en_US'], 'en'];
+        yield 'preferred_locales' => [['en_GB', 'en'], ['de', 'el', 'en_US'], 'en_GB'];
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-7862 |
|----------------|-----------|

<!-- 
#### Related PRs: 
    - https://github.com/ibexa/core/pull/1
-->

#### Description:
When a user has set preferred languages in his browser the first of them is taken into account. The current solution tries to find an intersection between preferred and available languages. 

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
