### PR TITLE
IBX-9584: Resolved Symfony 6.x deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,31 @@ jobs:
       - name: Run code style check
         run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
+  rector:
+    name: Run rector
+    runs-on: "ubuntu-22.04"
+    strategy:
+      matrix:
+        php:
+          - '8.3'
+    steps:
+      -   uses: actions/checkout@v4
+
+      -   name: Setup PHP Action
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: ${{ matrix.php }}
+            coverage: none
+            extensions: 'pdo_sqlite, gd'
+            tools: cs2pr
+
+      -   uses: ramsey/composer-install@v3
+          with:
+            dependency-versions: highest
+
+      -   name: Run rector
+          run: vendor/bin/rector process --dry-run --ansi
+
   tests:
     name: Tests
     runs-on: "ubuntu-22.04"

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "ibexa/doctrine-schema": "~5.0.x-dev",
         "ibexa/fieldtype-richtext": "~5.0.x-dev",
         "ibexa/http-cache": "~5.0.x-dev",
+        "ibexa/rector": "~5.0.x-dev",
         "ibexa/rest": "~5.0.x-dev",
         "ibexa/search": "~5.0.x-dev",
         "matthiasnoback/symfony-dependency-injection-test": "4.3",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -466,11 +466,6 @@ parameters:
 			path: src/lib/Form/Processor/UserRegisterFormProcessor.php
 
 		-
-			message: "#^Method Ibexa\\\\User\\\\Form\\\\Type\\\\Invitation\\\\InvitationType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Form/Type/Invitation/InvitationType.php
-
-		-
 			message: "#^Method Ibexa\\\\User\\\\Form\\\\Type\\\\Invitation\\\\RoleChoiceType\\:\\:loadFilteredRoles\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/lib/Form/Type/Invitation/RoleChoiceType.php
@@ -481,44 +476,9 @@ parameters:
 			path: src/lib/Form/Type/Invitation/UserGroupChoiceType.php
 
 		-
-			message: "#^Method Ibexa\\\\User\\\\Form\\\\Type\\\\Invitation\\\\UserInvitationType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Form/Type/Invitation/UserInvitationType.php
-
-		-
-			message: "#^Method Ibexa\\\\User\\\\Form\\\\Type\\\\UserPasswordChangeType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Form/Type/UserPasswordChangeType.php
-
-		-
-			message: "#^Method Ibexa\\\\User\\\\Form\\\\Type\\\\UserPasswordForgotType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Form/Type/UserPasswordForgotType.php
-
-		-
-			message: "#^Method Ibexa\\\\User\\\\Form\\\\Type\\\\UserPasswordForgotWithLoginType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Form/Type/UserPasswordForgotWithLoginType.php
-
-		-
-			message: "#^Method Ibexa\\\\User\\\\Form\\\\Type\\\\UserPasswordResetType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Form/Type/UserPasswordResetType.php
-
-		-
-			message: "#^Method Ibexa\\\\User\\\\Form\\\\Type\\\\UserRegisterType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Form/Type/UserRegisterType.php
-
-		-
 			message: "#^Method Ibexa\\\\User\\\\Form\\\\Type\\\\UserRegisterType\\:\\:getName\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/Form/Type/UserRegisterType.php
-
-		-
-			message: "#^Method Ibexa\\\\User\\\\Form\\\\Type\\\\UserSettingUpdateType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Form/Type/UserSettingUpdateType.php
 
 		-
 			message: "#^Method Ibexa\\\\User\\\\Invitation\\\\DomainMapper\\:\\:mapRoleLimitation\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withSets([
+        IbexaSetList::IBEXA_50->value,
+        SymfonySetList::SYMFONY_60,
+        SymfonySetList::SYMFONY_61,
+        SymfonySetList::SYMFONY_62,
+        SymfonySetList::SYMFONY_63,
+        SymfonySetList::SYMFONY_64,
+    ]);

--- a/src/lib/Form/Type/Invitation/InvitationType.php
+++ b/src/lib/Form/Type/Invitation/InvitationType.php
@@ -22,7 +22,7 @@ final class InvitationType extends AbstractType
         $this->invitationService = $invitationService;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addViewTransformer(new InvitationTransformer($this->invitationService));
     }

--- a/src/lib/Form/Type/Invitation/UserInvitationType.php
+++ b/src/lib/Form/Type/Invitation/UserInvitationType.php
@@ -23,7 +23,7 @@ final class UserInvitationType extends AbstractType
     public const LIMITATION_TYPE_SECTION = 'section';
     public const LIMITATION_TYPE_LOCATION = 'location';
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('email', EmailType::class, [
@@ -73,7 +73,7 @@ final class UserInvitationType extends AbstractType
         $builder->addModelTransformer(new LimitationValueTransformer());
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'data_class' => UserInvitationData::class,

--- a/src/lib/Form/Type/UserPasswordChangeType.php
+++ b/src/lib/Form/Type/UserPasswordChangeType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UserPasswordChangeType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('oldPassword', PasswordType::class, [

--- a/src/lib/Form/Type/UserPasswordForgotType.php
+++ b/src/lib/Form/Type/UserPasswordForgotType.php
@@ -17,7 +17,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UserPasswordForgotType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('email', EmailType::class, [
@@ -31,7 +31,7 @@ class UserPasswordForgotType extends AbstractType
             );
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'data_class' => UserPasswordForgotData::class,

--- a/src/lib/Form/Type/UserPasswordForgotWithLoginType.php
+++ b/src/lib/Form/Type/UserPasswordForgotWithLoginType.php
@@ -17,7 +17,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UserPasswordForgotWithLoginType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('login', TextType::class, [
@@ -31,7 +31,7 @@ class UserPasswordForgotWithLoginType extends AbstractType
             );
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'data_class' => UserPasswordForgotWithLoginData::class,

--- a/src/lib/Form/Type/UserPasswordResetType.php
+++ b/src/lib/Form/Type/UserPasswordResetType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UserPasswordResetType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('new_password', RepeatedType::class, [

--- a/src/lib/Form/Type/UserRegisterType.php
+++ b/src/lib/Form/Type/UserRegisterType.php
@@ -48,7 +48,7 @@ class UserRegisterType extends AbstractType
         return BaseContentType::class;
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('register', SubmitType::class, ['label' => /** @Desc("Register") */ 'user.register_button'])
@@ -72,7 +72,7 @@ class UserRegisterType extends AbstractType
         );
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setDefaults([

--- a/src/lib/Form/Type/UserSettingUpdateType.php
+++ b/src/lib/Form/Type/UserSettingUpdateType.php
@@ -45,7 +45,7 @@ class UserSettingUpdateType extends AbstractType
      *
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $groupDefinition = $this->valueDefinitionRegistry->getValueDefinitionGroup(
             $options['user_setting_group_identifier']
@@ -76,7 +76,7 @@ class UserSettingUpdateType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->setRequired('user_setting_group_identifier')


### PR DESCRIPTION
| :ticket: Issue | IBX-9584  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled and executed automatic refactoring rules defined for Symfony 6.x.

* [Form] Added missing return type declarations

Additionally added rector job to CI setup to prevent merging up code which is not compatible with Symfony 6+.

#### For QA:
Sanities.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
