### PR TITLE
[Twig] Removed usage of deprecated spaceless filter

### DIFF
--- a/src/bundle/Resources/views/permission/limiation/limitation_values.html.twig
+++ b/src/bundle/Resources/views/permission/limiation/limitation_values.html.twig
@@ -1,5 +1,3 @@
 {% block ez_limitation_hash_value %}
-    {% apply spaceless %}
-        {{ values|join(', ') }}
-    {% endapply %}
+    {{ values|join(', ') }}
 {% endblock %}


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:

> The spaceless filter is deprecated as of Twig 3.12 and will be removed in Twig 4.0.

See https://twig.symfony.com/doc/3.x/deprecated.html 

#### For QA:
Limitations and field types rendering.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
