### PR TITLE
IBX-9727: Added missing type hints

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,12 +13,6 @@ parameters:
 			path: src/bundle/Command/AuditUserDatabaseCommand.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\User\\Controller\\Controller\:\:performAccessCheck\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/Controller/Controller.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\User\\Controller\\DefaultProfileImageController\:\:getInitialsColors\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -97,28 +91,10 @@ parameters:
 			path: src/bundle/Controller/UserSettingsController.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\User\\Controller\\UserSettingsController\:\:updateAction\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/Controller/UserSettingsController.php
-
-		-
 			message: '#^PHPDoc tag @throws has invalid value \(\\Ibexa\\Core\\Base\\Exceptions\\InvalidArgumentException;\)\: Unexpected token ";", expected TOKEN_HORIZONTAL_WS at offset 337 on line 6$#'
 			identifier: phpDoc.parseError
 			count: 1
 			path: src/bundle/DependencyInjection/Compiler/UserSetting/FormMapperPass.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ChangePassword\:\:addSemanticConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/ChangePassword.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ChangePassword\:\:mapConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/ChangePassword.php
 
 		-
 			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ChangePassword\:\:mapConfig\(\) has parameter \$scopeSettings with no value type specified in iterable type array\.$#'
@@ -127,28 +103,10 @@ parameters:
 			path: src/bundle/DependencyInjection/Configuration/Parser/ChangePassword.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ForgotPassword\:\:addSemanticConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/ForgotPassword.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ForgotPassword\:\:mapConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/ForgotPassword.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ForgotPassword\:\:mapConfig\(\) has parameter \$scopeSettings with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/bundle/DependencyInjection/Configuration/Parser/ForgotPassword.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\Pagination\:\:addSemanticConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
 
 		-
 			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\Pagination\:\:mapConfig\(\) has parameter \$scopeSettings with no value type specified in iterable type array\.$#'
@@ -157,46 +115,16 @@ parameters:
 			path: src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ResetPassword\:\:addSemanticConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/ResetPassword.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ResetPassword\:\:mapConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/ResetPassword.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ResetPassword\:\:mapConfig\(\) has parameter \$scopeSettings with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/bundle/DependencyInjection/Configuration/Parser/ResetPassword.php
 
 		-
-			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\Security\:\:addSemanticConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/Security.php
-
-		-
 			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\Security\:\:mapConfig\(\) has parameter \$scopeSettings with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/bundle/DependencyInjection/Configuration/Parser/Security.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\UserInvitation\:\:addSemanticConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/UserInvitation.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\UserInvitation\:\:mapConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/UserInvitation.php
 
 		-
 			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\UserInvitation\:\:mapConfig\(\) has parameter \$scopeSettings with no value type specified in iterable type array\.$#'
@@ -209,18 +137,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/bundle/DependencyInjection/Configuration/Parser/UserPreferences.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\UserRegistration\:\:addSemanticConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
-
-		-
-			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\UserRegistration\:\:mapConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
 
 		-
 			message: '#^Method Ibexa\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\UserRegistration\:\:mapConfig\(\) has parameter \$scopeSettings with no value type specified in iterable type array\.$#'
@@ -415,42 +331,6 @@ parameters:
 			path: src/lib/Form/Data/UserInvitationData.php
 
 		-
-			message: '#^Property Ibexa\\User\\Form\\Data\\UserPasswordChangeData\:\:\$newPassword \(string\) does not accept string\|null\.$#'
-			identifier: assign.propertyType
-			count: 2
-			path: src/lib/Form/Data/UserPasswordChangeData.php
-
-		-
-			message: '#^Property Ibexa\\User\\Form\\Data\\UserPasswordChangeData\:\:\$oldPassword \(string\) does not accept string\|null\.$#'
-			identifier: assign.propertyType
-			count: 2
-			path: src/lib/Form/Data/UserPasswordChangeData.php
-
-		-
-			message: '#^Property Ibexa\\User\\Form\\Data\\UserPasswordForgotData\:\:\$email \(string\) does not accept string\|null\.$#'
-			identifier: assign.propertyType
-			count: 2
-			path: src/lib/Form/Data/UserPasswordForgotData.php
-
-		-
-			message: '#^Property Ibexa\\User\\Form\\Data\\UserPasswordForgotWithLoginData\:\:\$login \(string\) does not accept string\|null\.$#'
-			identifier: assign.propertyType
-			count: 2
-			path: src/lib/Form/Data/UserPasswordForgotWithLoginData.php
-
-		-
-			message: '#^Property Ibexa\\User\\Form\\Data\\UserPasswordResetData\:\:\$contentType \(Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\ContentType\) does not accept Ibexa\\Contracts\\Core\\Repository\\Values\\ContentType\\ContentType\|null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/lib/Form/Data/UserPasswordResetData.php
-
-		-
-			message: '#^Property Ibexa\\User\\Form\\Data\\UserPasswordResetData\:\:\$newPassword \(string\) does not accept string\|null\.$#'
-			identifier: assign.propertyType
-			count: 2
-			path: src/lib/Form/Data/UserPasswordResetData.php
-
-		-
 			message: '#^Method Ibexa\\User\\Form\\Data\\UserSettingUpdateData\:\:__construct\(\) has parameter \$values with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -469,26 +349,8 @@ parameters:
 			path: src/lib/Form/Data/UserSettingUpdateData.php
 
 		-
-			message: '#^Call to an undefined method Ibexa\\User\\ConfigResolver\\RegistrationContentTypeLoader\:\:loadGroup\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: src/lib/Form/DataMapper/UserRegisterMapper.php
-
-		-
 			message: '#^Method Ibexa\\User\\ConfigResolver\\RegistrationContentTypeLoader\:\:loadContentType\(\) invoked with 1 parameter, 0 required\.$#'
 			identifier: arguments.count
-			count: 1
-			path: src/lib/Form/DataMapper/UserRegisterMapper.php
-
-		-
-			message: '#^Method Ibexa\\User\\Form\\DataMapper\\UserRegisterMapper\:\:configureOptions\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Form/DataMapper/UserRegisterMapper.php
-
-		-
-			message: '#^Method Ibexa\\User\\Form\\DataMapper\\UserRegisterMapper\:\:setParam\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/lib/Form/DataMapper/UserRegisterMapper.php
 
@@ -505,14 +367,14 @@ parameters:
 			path: src/lib/Form/DataMapper/UserRegisterMapper.php
 
 		-
-			message: '#^Property Ibexa\\User\\Form\\DataMapper\\UserRegisterMapper\:\:\$params type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: '#^PHPDoc tag @var for property Ibexa\\User\\Form\\DataMapper\\UserRegisterMapper\:\:\$parentGroupLoader with type Ibexa\\User\\ConfigResolver\\RegistrationContentTypeLoader is not subtype of native type Ibexa\\User\\ConfigResolver\\RegistrationGroupLoader\.$#'
+			identifier: property.phpDocType
 			count: 1
 			path: src/lib/Form/DataMapper/UserRegisterMapper.php
 
 		-
-			message: '#^Property Ibexa\\User\\Form\\DataMapper\\UserRegisterMapper\:\:\$parentGroupLoader \(Ibexa\\User\\ConfigResolver\\RegistrationContentTypeLoader\) does not accept Ibexa\\User\\ConfigResolver\\RegistrationGroupLoader\.$#'
-			identifier: assign.propertyType
+			message: '#^Property Ibexa\\User\\Form\\DataMapper\\UserRegisterMapper\:\:\$params type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/Form/DataMapper/UserRegisterMapper.php
 
@@ -611,12 +473,6 @@ parameters:
 			identifier: argument.type
 			count: 5
 			path: src/lib/Form/Factory/FormFactory.php
-
-		-
-			message: '#^Method Ibexa\\User\\Form\\Processor\\UserRegisterFormProcessor\:\:processRegister\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Form/Processor/UserRegisterFormProcessor.php
 
 		-
 			message: '#^Variable \$data in PHPDoc tag @var does not exist\.$#'
@@ -735,12 +591,6 @@ parameters:
 		-
 			message: '#^Class Ibexa\\User\\Form\\Type\\UserRegisterType extends generic class Symfony\\Component\\Form\\AbstractType but does not specify its types\: TData$#'
 			identifier: missingType.generics
-			count: 1
-			path: src/lib/Form/Type/UserRegisterType.php
-
-		-
-			message: '#^Method Ibexa\\User\\Form\\Type\\UserRegisterType\:\:getName\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/lib/Form/Type/UserRegisterType.php
 
@@ -865,18 +715,6 @@ parameters:
 			path: src/lib/Pagination/Pagerfanta/UserSettingsAdapter.php
 
 		-
-			message: '#^Method Ibexa\\User\\Permission\\InvitationPolicyProvider\:\:addPolicies\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Permission/InvitationPolicyProvider.php
-
-		-
-			message: '#^Method Ibexa\\User\\Permission\\UserPermissionsLimitationType\:\:acceptValue\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/Permission/UserPermissionsLimitationType.php
-
-		-
 			message: '#^Method Ibexa\\User\\Permission\\UserPermissionsLimitationType\:\:evaluate\(\) should return bool but returns null\.$#'
 			identifier: return.type
 			count: 1
@@ -961,12 +799,6 @@ parameters:
 			path: src/lib/UserSetting/Group/LocationGroup.php
 
 		-
-			message: '#^Cannot call method format\(\) on Ibexa\\User\\UserSetting\\DateTimeFormat\\Formatter\|null\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/lib/UserSetting/Setting/AbstractDateTimeFormat.php
-
-		-
 			message: '#^Cannot call method getDateFormat\(\) on Ibexa\\User\\UserSetting\\Setting\\Value\\DateTimeFormat\|null\.$#'
 			identifier: method.nonObject
 			count: 1
@@ -979,7 +811,13 @@ parameters:
 			path: src/lib/UserSetting/Setting/AbstractDateTimeFormat.php
 
 		-
-			message: '#^Property Ibexa\\User\\UserSetting\\Setting\\AbstractDateTimeFormat\:\:\$formatter \(Ibexa\\User\\UserSetting\\DateTimeFormat\\Formatter\|null\) does not accept Ibexa\\User\\UserSetting\\DateTimeFormat\\FormatterInterface\.$#'
+			message: '#^PHPDoc tag @var for property Ibexa\\User\\UserSetting\\Setting\\AbstractDateTimeFormat\:\:\$formatter with type Ibexa\\User\\UserSetting\\DateTimeFormat\\Formatter\|null is not subtype of native type Ibexa\\User\\UserSetting\\DateTimeFormat\\FormatterInterface\.$#'
+			identifier: property.phpDocType
+			count: 1
+			path: src/lib/UserSetting/Setting/AbstractDateTimeFormat.php
+
+		-
+			message: '#^Property Ibexa\\User\\UserSetting\\Setting\\AbstractDateTimeFormat\:\:\$formatter \(Ibexa\\User\\UserSetting\\DateTimeFormat\\Formatter\) does not accept Ibexa\\User\\UserSetting\\DateTimeFormat\\FormatterInterface\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/lib/UserSetting/Setting/AbstractDateTimeFormat.php
@@ -1075,18 +913,6 @@ parameters:
 			path: src/lib/UserSetting/Setting/Timezone.php
 
 		-
-			message: '#^Method Ibexa\\User\\UserSetting\\Setting\\Value\\DateTimeFormat\:\:setDateFormat\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/UserSetting/Setting/Value/DateTimeFormat.php
-
-		-
-			message: '#^Method Ibexa\\User\\UserSetting\\Setting\\Value\\DateTimeFormat\:\:setTimeFormat\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/UserSetting/Setting/Value/DateTimeFormat.php
-
-		-
 			message: '#^Class Ibexa\\User\\UserSetting\\UserSettingArrayAccessor implements generic interface ArrayAccess but does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
 			count: 1
@@ -1109,12 +935,6 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: src/lib/UserSetting/UserSettingGroup.php
-
-		-
-			message: '#^Method Ibexa\\User\\UserSetting\\UserSettingService\:\:countGroupedUserSettings\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/lib/UserSetting/UserSettingService.php
 
 		-
 			message: '#^Method Ibexa\\User\\UserSetting\\UserSettingService\:\:createUserSettingsGroup\(\) has parameter \$userPreferences with no value type specified in iterable type array\.$#'
@@ -1261,32 +1081,14 @@ parameters:
 			path: tests/bundle/DependencyInjection/Configuration/Parser/ChangePasswordTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ChangePasswordTest\:\:testOverwrittenConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/Configuration/Parser/ChangePasswordTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ForgotPasswordTest\:\:getMinimalConfiguration\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/bundle/DependencyInjection/Configuration/Parser/ForgotPasswordTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ForgotPasswordTest\:\:testOverwrittenConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/bundle/DependencyInjection/Configuration/Parser/ForgotPasswordTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ResetPasswordTest\:\:getMinimalConfiguration\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/bundle/DependencyInjection/Configuration/Parser/ResetPasswordTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\Bundle\\User\\DependencyInjection\\Configuration\\Parser\\ResetPasswordTest\:\:testOverwrittenConfig\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/bundle/DependencyInjection/Configuration/Parser/ResetPasswordTest.php
 
@@ -1339,52 +1141,16 @@ parameters:
 			path: tests/lib/Permission/UserPermissionsLimitationTypeTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\User\\Permission\\UserPermissionsLimitationTypeTest\:\:providerForTestEvaluate\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: '#^Method Ibexa\\Tests\\User\\Permission\\UserPermissionsLimitationTypeTest\:\:providerForTestEvaluate\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/Permission/UserPermissionsLimitationTypeTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\User\\Permission\\UserPermissionsLimitationTypeTest\:\:providerForTestValidateError\(\) has no return type specified\.$#'
-			identifier: missingType.return
+			message: '#^Method Ibexa\\Tests\\User\\Permission\\UserPermissionsLimitationTypeTest\:\:providerForTestValidateError\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: tests/lib/Permission/UserPermissionsLimitationTypeTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\User\\UserSetting\\ValueDefinitionRegistryTest\:\:testAddValueDefinition\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/UserSetting/ValueDefinitionRegistryTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\User\\UserSetting\\ValueDefinitionRegistryTest\:\:testCountValueDefinitions\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/UserSetting/ValueDefinitionRegistryTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\User\\UserSetting\\ValueDefinitionRegistryTest\:\:testCountValueDefinitionsWithEmptyRegistry\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/UserSetting/ValueDefinitionRegistryTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\User\\UserSetting\\ValueDefinitionRegistryTest\:\:testGetValueDefinition\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/UserSetting/ValueDefinitionRegistryTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\User\\UserSetting\\ValueDefinitionRegistryTest\:\:testGetValueDefinitions\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/UserSetting/ValueDefinitionRegistryTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\User\\UserSetting\\ValueDefinitionRegistryTest\:\:testHasValueDefinition\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/UserSetting/ValueDefinitionRegistryTest.php
 
 		-
 			message: '#^Call to method PHPUnit\\Framework\\Assert\:\:assertInstanceOf\(\) with ''Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\User\\\\PasswordValidationContext'' and Ibexa\\Contracts\\Core\\Repository\\Values\\User\\PasswordValidationContext will always evaluate to true\.$#'
@@ -1405,38 +1171,8 @@ parameters:
 			path: tests/lib/Validator/Constraint/PasswordValidatorTest.php
 
 		-
-			message: '#^Method Ibexa\\Tests\\User\\Validator\\Constraint\\PasswordValidatorTest\:\:testValidateShouldBeSkipped\(\) has parameter \$value with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: tests/lib/Validator/Constraint/PasswordValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\User\\Validator\\Constraint\\UserPasswordTest\:\:testConstruct\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Validator/Constraint/UserPasswordTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\User\\Validator\\Constraint\\UserPasswordValidatorTest\:\:emptyDataProvider\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/lib/Validator/Constraint/UserPasswordValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\User\\Validator\\Constraint\\UserPasswordValidatorTest\:\:testEmptyValueType\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Validator/Constraint/UserPasswordValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\User\\Validator\\Constraint\\UserPasswordValidatorTest\:\:testInvalid\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: tests/lib/Validator/Constraint/UserPasswordValidatorTest.php
-
-		-
-			message: '#^Method Ibexa\\Tests\\User\\Validator\\Constraint\\UserPasswordValidatorTest\:\:testValid\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: tests/lib/Validator/Constraint/UserPasswordValidatorTest.php
 

--- a/src/bundle/Command/AuditUserDatabaseCommand.php
+++ b/src/bundle/Command/AuditUserDatabaseCommand.php
@@ -20,14 +20,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class AuditUserDatabaseCommand extends Command
 {
-    /** @var \Ibexa\Contracts\Core\Repository\ContentTypeService */
-    private $contentTypeService;
+    private ContentTypeService $contentTypeService;
 
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    private $userService;
+    private UserService $userService;
 
-    /** @var \Doctrine\DBAL\Connection */
-    private $connection;
+    private Connection $connection;
 
     public function __construct(
         ContentTypeService $contentTypeService,

--- a/src/bundle/Controller/Controller.php
+++ b/src/bundle/Controller/Controller.php
@@ -12,7 +12,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 abstract class Controller extends AbstractController
 {
-    public function performAccessCheck()
+    public function performAccessCheck(): void
     {
         $this->denyAccessUnlessGranted('IS_AUTHENTICATED_REMEMBERED');
     }

--- a/src/bundle/Controller/PasswordChangeController.php
+++ b/src/bundle/Controller/PasswordChangeController.php
@@ -16,25 +16,21 @@ use Ibexa\User\Form\Factory\FormFactory;
 use Ibexa\User\View\ChangePassword\FormView;
 use Ibexa\User\View\ChangePassword\SuccessView;
 use JMS\TranslationBundle\Annotation\Desc;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class PasswordChangeController extends Controller
 {
-    /** @var \Ibexa\User\ExceptionHandler\ActionResultHandler */
-    private $actionResultHandler;
+    private ActionResultHandler $actionResultHandler;
 
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    private $userService;
+    private UserService $userService;
 
-    /** @var \Ibexa\User\Form\Factory\FormFactory */
-    private $formFactory;
+    private FormFactory $formFactory;
 
-    /** @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface */
-    private $tokenStorage;
+    private TokenStorageInterface $tokenStorage;
 
-    /** @var array */
-    private $siteAccessGroups;
+    private array $siteAccessGroups;
 
     public function __construct(
         ActionResultHandler $actionResultHandler,
@@ -57,7 +53,7 @@ class PasswordChangeController extends Controller
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      */
-    public function userPasswordChangeAction(Request $request)
+    public function userPasswordChangeAction(Request $request): RedirectResponse|SuccessView|FormView
     {
         /** @var \Ibexa\Contracts\Core\Repository\Values\User\User $user */
         $user = $this->tokenStorage->getToken()->getUser()->getAPIUser();

--- a/src/bundle/Controller/PasswordResetController.php
+++ b/src/bundle/Controller/PasswordResetController.php
@@ -31,6 +31,7 @@ use Ibexa\User\View\ForgotPassword\SuccessView;
 use Ibexa\User\View\ResetPassword\FormView as UserResetPasswordFormView;
 use Ibexa\User\View\ResetPassword\InvalidLinkView;
 use Ibexa\User\View\ResetPassword\SuccessView as UserResetPasswordSuccessView;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
@@ -74,7 +75,7 @@ class PasswordResetController extends Controller
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      */
-    public function userForgotPasswordAction(Request $request, ?string $reason = null)
+    public function userForgotPasswordAction(Request $request, ?string $reason = null): RedirectResponse|SuccessView|FormView
     {
         $form = $this->formFactory->forgotUserPassword();
         $form->handleRequest($request);
@@ -112,7 +113,7 @@ class PasswordResetController extends Controller
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      */
-    public function userForgotPasswordLoginAction(Request $request)
+    public function userForgotPasswordLoginAction(Request $request): SuccessView|LoginView
     {
         $form = $this->formFactory->forgotUserPasswordWithLogin();
 
@@ -150,7 +151,7 @@ class PasswordResetController extends Controller
      *
      * @throws \Ibexa\Core\Base\Exceptions\InvalidArgumentType
      */
-    public function userResetPasswordAction(Request $request, string $hashKey)
+    public function userResetPasswordAction(Request $request, string $hashKey): InvalidLinkView|UserResetPasswordSuccessView|UserResetPasswordFormView
     {
         $response = new Response();
         $response->headers->set('X-Robots-Tag', 'noindex');

--- a/src/bundle/Controller/PasswordResetController.php
+++ b/src/bundle/Controller/PasswordResetController.php
@@ -10,6 +10,7 @@ namespace Ibexa\Bundle\User\Controller;
 
 use DateInterval;
 use DateTime;
+use Exception;
 use Ibexa\Bundle\User\Type\UserForgotPasswordReason;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
@@ -85,7 +86,7 @@ class PasswordResetController extends Controller
             $users = $this->userService->loadUsersByEmail($data->getEmail());
 
             /** Because it is possible to have multiple user accounts with same email address we must gain a user login. */
-            if (\count($users) > 1) {
+            if (count($users) > 1) {
                 return $this->redirectToRoute('ibexa.user.forgot_password.login');
             }
 
@@ -128,7 +129,7 @@ class PasswordResetController extends Controller
                 $user = null;
             }
 
-            if (!$user || \count($this->userService->loadUsersByEmail($user->email)) < 2) {
+            if (!$user || count($this->userService->loadUsersByEmail($user->email)) < 2) {
                 return new SuccessView(null);
             }
 
@@ -195,7 +196,7 @@ class PasswordResetController extends Controller
                 $view->setResponse($response);
 
                 return $view;
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $this->actionResultHandler->error($e->getMessage());
             }
         }

--- a/src/bundle/Controller/UserRegisterController.php
+++ b/src/bundle/Controller/UserRegisterController.php
@@ -20,11 +20,9 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class UserRegisterController extends Controller
 {
-    /** @var \Ibexa\User\Form\DataMapper\UserRegisterMapper */
-    private $userRegisterMapper;
+    private UserRegisterMapper $userRegisterMapper;
 
-    /** @var \Ibexa\ContentForms\Form\ActionDispatcher\ActionDispatcherInterface */
-    private $userActionDispatcher;
+    private ActionDispatcherInterface $userActionDispatcher;
 
     private InvitationService $invitationService;
 

--- a/src/bundle/Controller/UserSettingsController.php
+++ b/src/bundle/Controller/UserSettingsController.php
@@ -87,7 +87,7 @@ class UserSettingsController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
-            $result = $this->submitHandler->handle($form, function (UserSettingUpdateData $data) use ($form): \Symfony\Component\HttpFoundation\RedirectResponse {
+            $result = $this->submitHandler->handle($form, function (UserSettingUpdateData $data) use ($form): RedirectResponse {
                 foreach ($data->getValues() as $identifier => $value) {
                     $this->userSettingService->setUserSetting($identifier, (string)$value['value']);
                 }

--- a/src/bundle/Controller/UserSettingsController.php
+++ b/src/bundle/Controller/UserSettingsController.php
@@ -26,20 +26,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 class UserSettingsController extends Controller
 {
-    /** @var \Ibexa\User\Form\Factory\FormFactory */
-    private $formFactory;
+    private FormFactory $formFactory;
 
-    /** @var \Ibexa\User\Form\SubmitHandler */
-    private $submitHandler;
+    private SubmitHandler $submitHandler;
 
-    /** @var \Ibexa\User\UserSetting\UserSettingService */
-    private $userSettingService;
+    private UserSettingService $userSettingService;
 
-    /** @var \Ibexa\User\UserSetting\ValueDefinitionRegistry */
-    private $valueDefinitionRegistry;
+    private ValueDefinitionRegistry $valueDefinitionRegistry;
 
-    /** @var \Ibexa\User\ExceptionHandler\ActionResultHandler */
-    private $actionResultHandler;
+    private ActionResultHandler $actionResultHandler;
 
     private PermissionResolver $permissionResolver;
 
@@ -78,7 +73,7 @@ class UserSettingsController extends Controller
         ]);
     }
 
-    public function updateAction(Request $request, UpdateView $view)
+    public function updateAction(Request $request, UpdateView $view): Response|UpdateView
     {
         $userSettingGroup = $view->getUserSettingGroup();
 
@@ -92,7 +87,7 @@ class UserSettingsController extends Controller
         $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
-            $result = $this->submitHandler->handle($form, function (UserSettingUpdateData $data) use ($form) {
+            $result = $this->submitHandler->handle($form, function (UserSettingUpdateData $data) use ($form): \Symfony\Component\HttpFoundation\RedirectResponse {
                 foreach ($data->getValues() as $identifier => $value) {
                     $this->userSettingService->setUserSetting($identifier, (string)$value['value']);
                 }

--- a/src/bundle/DependencyInjection/Configuration/Parser/ChangePassword.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/ChangePassword.php
@@ -19,7 +19,7 @@ class ChangePassword extends AbstractParser
      *
      * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
      */
-    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {
         $nodeBuilder
             ->arrayNode('user_change_password')
@@ -40,7 +40,7 @@ class ChangePassword extends AbstractParser
             ->end();
     }
 
-    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
         if (empty($scopeSettings['user_change_password'])) {
             return;

--- a/src/bundle/DependencyInjection/Configuration/Parser/ForgotPassword.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/ForgotPassword.php
@@ -14,7 +14,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 final class ForgotPassword extends AbstractParser
 {
-    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {
         $nodeBuilder
             ->arrayNode('user_forgot_password')
@@ -60,7 +60,7 @@ final class ForgotPassword extends AbstractParser
         ;
     }
 
-    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
         if (!empty($scopeSettings['user_forgot_password'])) {
             $settings = $scopeSettings['user_forgot_password']['templates'];

--- a/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Pagination.php
@@ -26,7 +26,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
  */
 class Pagination extends AbstractParser
 {
-    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {
         $nodeBuilder
             ->arrayNode('pagination_user')

--- a/src/bundle/DependencyInjection/Configuration/Parser/ResetPassword.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/ResetPassword.php
@@ -14,7 +14,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 
 final class ResetPassword extends AbstractParser
 {
-    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {
         $nodeBuilder
             ->arrayNode('user_reset_password')
@@ -39,7 +39,7 @@ final class ResetPassword extends AbstractParser
         ;
     }
 
-    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
         if (empty($scopeSettings['user_reset_password'])) {
             return;

--- a/src/bundle/DependencyInjection/Configuration/Parser/Security.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Security.php
@@ -22,7 +22,7 @@ class Security extends AbstractParser
      *
      * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
      */
-    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {
         $nodeBuilder
             ->arrayNode('security')

--- a/src/bundle/DependencyInjection/Configuration/Parser/UserInvitation.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/UserInvitation.php
@@ -31,7 +31,7 @@ class UserInvitation extends AbstractParser
      *
      * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
      */
-    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {
         $nodeBuilder
             ->arrayNode('user_invitation')
@@ -55,7 +55,7 @@ class UserInvitation extends AbstractParser
             ->end();
     }
 
-    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
         if (empty($scopeSettings['user_invitation'])) {
             return;

--- a/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
@@ -19,7 +19,7 @@ class UserRegistration extends AbstractParser
      *
      * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
      */
-    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    public function addSemanticConfig(NodeBuilder $nodeBuilder): void
     {
         $nodeBuilder
             ->arrayNode('user_registration')
@@ -62,7 +62,7 @@ class UserRegistration extends AbstractParser
             ->end();
     }
 
-    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
         if (empty($scopeSettings['user_registration'])) {
             return;

--- a/src/lib/Behat/Context/UserSettingsContext.php
+++ b/src/lib/Behat/Context/UserSettingsContext.php
@@ -14,20 +14,11 @@ use Ibexa\User\UserSetting\UserSettingService;
 
 class UserSettingsContext implements Context
 {
-    /**
-     * @var \Ibexa\User\UserSetting\UserSettingService
-     */
-    private $userSettingService;
+    private UserSettingService $userSettingService;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\PermissionResolver
-     */
-    private $permissionResolver;
+    private PermissionResolver $permissionResolver;
 
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\UserService
-     */
-    private $userService;
+    private UserService $userService;
 
     public function __construct(UserSettingService $userSettingService, PermissionResolver $permissionResolver, UserService $userService)
     {

--- a/src/lib/Behat/Context/UserSetupContext.php
+++ b/src/lib/Behat/Context/UserSetupContext.php
@@ -16,8 +16,7 @@ class UserSetupContext implements Context
 {
     private const UNSUPPORTED_USER_HASH = 5;
 
-    /** @var \Doctrine\DBAL\Connection */
-    private $connection;
+    private Connection $connection;
 
     public function __construct(Connection $connection)
     {

--- a/src/lib/ConfigResolver/ConfigurableRegistrationContentTypeLoader.php
+++ b/src/lib/ConfigResolver/ConfigurableRegistrationContentTypeLoader.php
@@ -10,6 +10,7 @@ namespace Ibexa\User\ConfigResolver;
 
 use Ibexa\Contracts\Core\Repository\ContentTypeService;
 use Ibexa\Contracts\Core\Repository\Repository;
+use Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 
 /**
@@ -36,7 +37,7 @@ class ConfigurableRegistrationContentTypeLoader implements RegistrationContentTy
     public function loadContentType(?string $siteAccessIdentifier = null)
     {
         return $this->repository->sudo(
-            fn (): \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType => $this->contentTypeService->loadContentTypeByIdentifier(
+            fn (): ContentType => $this->contentTypeService->loadContentTypeByIdentifier(
                 $this->configResolver->getParameter(
                     'user_registration.user_type_identifier',
                     null,

--- a/src/lib/ConfigResolver/ConfigurableRegistrationContentTypeLoader.php
+++ b/src/lib/ConfigResolver/ConfigurableRegistrationContentTypeLoader.php
@@ -36,7 +36,7 @@ class ConfigurableRegistrationContentTypeLoader implements RegistrationContentTy
     public function loadContentType(?string $siteAccessIdentifier = null)
     {
         return $this->repository->sudo(
-            fn () => $this->contentTypeService->loadContentTypeByIdentifier(
+            fn (): \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType => $this->contentTypeService->loadContentTypeByIdentifier(
                 $this->configResolver->getParameter(
                     'user_registration.user_type_identifier',
                     null,

--- a/src/lib/ConfigResolver/ConfigurableRegistrationGroupLoader.php
+++ b/src/lib/ConfigResolver/ConfigurableRegistrationGroupLoader.php
@@ -17,11 +17,9 @@ use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
  */
 class ConfigurableRegistrationGroupLoader implements RegistrationGroupLoader
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
-    /** @var \Ibexa\Contracts\Core\Repository\Repository */
-    private $repository;
+    private Repository $repository;
 
     public function __construct(ConfigResolverInterface $configResolver, Repository $repository)
     {

--- a/src/lib/ConfigResolver/ConfigurableSudoRepositoryLoader.php
+++ b/src/lib/ConfigResolver/ConfigurableSudoRepositoryLoader.php
@@ -26,8 +26,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 abstract class ConfigurableSudoRepositoryLoader
 {
-    /** @var \Ibexa\Contracts\Core\Repository\Repository */
-    private $repository;
+    private Repository $repository;
 
     /** @var array */
     private $params;

--- a/src/lib/EventListener/ViewTemplatesListener.php
+++ b/src/lib/EventListener/ViewTemplatesListener.php
@@ -17,8 +17,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ViewTemplatesListener implements EventSubscriberInterface
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(ConfigResolverInterface $configResolver)
     {

--- a/src/lib/Form/Data/UserPasswordChangeData.php
+++ b/src/lib/Form/Data/UserPasswordChangeData.php
@@ -15,17 +15,12 @@ class UserPasswordChangeData
 {
     /**
      * @UserAssert\UserPassword()
-     *
-     * @var string
      */
     #[Assert\NotBlank]
-    private $oldPassword;
+    private ?string $oldPassword;
 
-    /**
-     * @var string
-     */
     #[Assert\NotBlank]
-    private $newPassword;
+    private ?string $newPassword;
 
     /**
      * @param string|null $oldPassword

--- a/src/lib/Form/Data/UserPasswordForgotData.php
+++ b/src/lib/Form/Data/UserPasswordForgotData.php
@@ -12,11 +12,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class UserPasswordForgotData
 {
-    /**
-     * @var string
-     */
     #[Assert\NotBlank]
-    private $email;
+    private ?string $email;
 
     /**
      * @param string|null $email

--- a/src/lib/Form/Data/UserPasswordForgotWithLoginData.php
+++ b/src/lib/Form/Data/UserPasswordForgotWithLoginData.php
@@ -12,11 +12,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class UserPasswordForgotWithLoginData
 {
-    /**
-     * @var string
-     */
     #[Assert\NotBlank]
-    private $login;
+    private ?string $login;
 
     /**
      * @param string|null $login

--- a/src/lib/Form/Data/UserPasswordResetData.php
+++ b/src/lib/Form/Data/UserPasswordResetData.php
@@ -13,18 +13,13 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class UserPasswordResetData
 {
-    /**
-     * @var string
-     */
     #[Assert\NotBlank]
-    private $newPassword;
+    private ?string $newPassword;
 
     /**
      * @deprecated ContentType should be passed as option to FormType.
-     *
-     * @var \Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType
      */
-    private $contentType;
+    private ?ContentType $contentType;
 
     /**
      * @param string|null $newPassword

--- a/src/lib/Form/DataMapper/UserRegisterMapper.php
+++ b/src/lib/Form/DataMapper/UserRegisterMapper.php
@@ -20,11 +20,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class UserRegisterMapper
 {
-    /** @var \Ibexa\User\ConfigResolver\RegistrationContentTypeLoader */
-    private $contentTypeLoader;
+    private RegistrationContentTypeLoader $contentTypeLoader;
 
     /** @var \Ibexa\User\ConfigResolver\RegistrationContentTypeLoader */
-    private $parentGroupLoader;
+    private RegistrationGroupLoader $parentGroupLoader;
 
     /** @var array */
     private $params;
@@ -45,7 +44,7 @@ class UserRegisterMapper
      * @param $name
      * @param $value
      */
-    public function setParam($name, $value)
+    public function setParam($name, $value): void
     {
         $this->params[$name] = $value;
     }
@@ -53,7 +52,7 @@ class UserRegisterMapper
     /**
      * @return \Ibexa\User\Form\Data\UserRegisterData
      */
-    public function mapToFormData()
+    public function mapToFormData(): UserRegisterData
     {
         $resolver = new OptionsResolver();
         $this->configureOptions($resolver);
@@ -104,7 +103,7 @@ class UserRegisterMapper
         return $data;
     }
 
-    private function configureOptions(OptionsResolver $optionsResolver)
+    private function configureOptions(OptionsResolver $optionsResolver): void
     {
         $optionsResolver
             ->setRequired('language')

--- a/src/lib/Form/DataTransformer/DateTimeFormatTransformer.php
+++ b/src/lib/Form/DataTransformer/DateTimeFormatTransformer.php
@@ -15,8 +15,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 
 class DateTimeFormatTransformer implements DataTransformerInterface
 {
-    /** @var \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer */
-    private $serializer;
+    private DateTimeFormatSerializer $serializer;
 
     /**
      * @param \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer $serializer

--- a/src/lib/Form/DataTransformer/DateTimeFormatTransformer.php
+++ b/src/lib/Form/DataTransformer/DateTimeFormatTransformer.php
@@ -34,9 +34,9 @@ class DateTimeFormatTransformer implements DataTransformerInterface
             return null;
         }
 
-        if (!\is_string($value)) {
+        if (!is_string($value)) {
             throw new TransformationFailedException(
-                sprintf('Received %s instead of %s', \gettype($value), 'string')
+                sprintf('Received %s instead of %s', gettype($value), 'string')
             );
         }
 
@@ -57,9 +57,9 @@ class DateTimeFormatTransformer implements DataTransformerInterface
             return null;
         }
 
-        if (!\is_array($value)) {
+        if (!is_array($value)) {
             throw new TransformationFailedException(
-                sprintf('Received %s instead of an array', \gettype($value))
+                sprintf('Received %s instead of an array', gettype($value))
             );
         }
 

--- a/src/lib/Form/Factory/FormFactory.php
+++ b/src/lib/Form/Factory/FormFactory.php
@@ -27,11 +27,9 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class FormFactory
 {
-    /** @var \Symfony\Component\Form\FormFactoryInterface */
-    protected $formFactory;
+    protected FormFactoryInterface $formFactory;
 
-    /** @var \Symfony\Component\Routing\Generator\UrlGeneratorInterface */
-    protected $urlGenerator;
+    protected UrlGeneratorInterface $urlGenerator;
 
     /**
      * @param \Symfony\Component\Form\FormFactoryInterface $formFactory

--- a/src/lib/Form/Processor/UserRegisterFormProcessor.php
+++ b/src/lib/Form/Processor/UserRegisterFormProcessor.php
@@ -65,7 +65,7 @@ class UserRegisterFormProcessor implements EventSubscriberInterface
      *
      * @throws \Exception
      */
-    public function processRegister(FormActionEvent $event)
+    public function processRegister(FormActionEvent $event): void
     {
         /** @var \Ibexa\User\Form\Data\UserRegisterData $data */
         if (!($data = $event->getData()) instanceof UserRegisterData) {
@@ -88,7 +88,7 @@ class UserRegisterFormProcessor implements EventSubscriberInterface
         }
 
         return $this->repository->sudo(
-            function () use ($data) {
+            function () use ($data): \Ibexa\Contracts\Core\Repository\Values\User\User {
                 $user = $this->userService->createUser($data, $data->getParentGroups());
                 if ($data->getRole() !== null) {
                     $this->roleService->assignRoleToUser($data->getRole(), $user, $data->getRoleLimitation());

--- a/src/lib/Form/Processor/UserRegisterFormProcessor.php
+++ b/src/lib/Form/Processor/UserRegisterFormProcessor.php
@@ -88,7 +88,7 @@ class UserRegisterFormProcessor implements EventSubscriberInterface
         }
 
         return $this->repository->sudo(
-            function () use ($data): \Ibexa\Contracts\Core\Repository\Values\User\User {
+            function () use ($data): User {
                 $user = $this->userService->createUser($data, $data->getParentGroups());
                 if ($data->getRole() !== null) {
                     $this->roleService->assignRoleToUser($data->getRole(), $user, $data->getRoleLimitation());

--- a/src/lib/Form/Type/Invitation/RoleChoiceType.php
+++ b/src/lib/Form/Type/Invitation/RoleChoiceType.php
@@ -48,8 +48,8 @@ final class RoleChoiceType extends AbstractType
     public function loadFilteredRoles(): array
     {
         return array_filter(
-            $this->repository->sudo(fn () => $this->roleService->loadRoles()),
-            fn ($role) => $this->permissionResolver->canUser('user', 'invite', $role)
+            $this->repository->sudo(fn (): iterable => $this->roleService->loadRoles()),
+            fn ($role): bool => $this->permissionResolver->canUser('user', 'invite', $role)
         );
     }
 

--- a/src/lib/Form/Type/Invitation/SectionsChoiceType.php
+++ b/src/lib/Form/Type/Invitation/SectionsChoiceType.php
@@ -35,7 +35,7 @@ final class SectionsChoiceType extends AbstractType
             ->setDefaults([
                 'choice_loader' => ChoiceList::lazy(
                     $this,
-                    fn () => $this->repository->sudo(fn () => $this->sectionService->loadSections())
+                    fn () => $this->repository->sudo(fn (): iterable => $this->sectionService->loadSections())
                 ),
                 'choice_label' => 'name',
                 'choice_value' => 'id',

--- a/src/lib/Form/Type/Invitation/UserGroupChoiceType.php
+++ b/src/lib/Form/Type/Invitation/UserGroupChoiceType.php
@@ -67,7 +67,7 @@ final class UserGroupChoiceType extends AbstractType
                 $this->searchService,
                 $this->userService
             ))->loadChoiceList()->getChoices(),
-            fn ($group) => $this->permissionResolver->canUser('user', 'invite', $group)
+            fn ($group): bool => $this->permissionResolver->canUser('user', 'invite', $group)
         );
     }
 }

--- a/src/lib/Form/Type/UserRegisterType.php
+++ b/src/lib/Form/Type/UserRegisterType.php
@@ -33,7 +33,7 @@ class UserRegisterType extends AbstractType
         $this->configResolver = $configResolver;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->getBlockPrefix();
     }

--- a/src/lib/Form/Type/UserSettingUpdateType.php
+++ b/src/lib/Form/Type/UserSettingUpdateType.php
@@ -22,11 +22,9 @@ class UserSettingUpdateType extends AbstractType
 {
     public const BTN_UPDATE_AND_EDIT = 'update_and_edit';
 
-    /** @var \Ibexa\User\UserSetting\FormMapperRegistry */
-    protected $formMapperRegistry;
+    protected FormMapperRegistry $formMapperRegistry;
 
-    /** @var \Ibexa\User\UserSetting\ValueDefinitionRegistry */
-    protected $valueDefinitionRegistry;
+    protected ValueDefinitionRegistry $valueDefinitionRegistry;
 
     /**
      * @param \Ibexa\User\UserSetting\FormMapperRegistry $formMapperRegistry

--- a/src/lib/Form/Type/UserSettings/FullDateTimeFormatType.php
+++ b/src/lib/Form/Type/UserSettings/FullDateTimeFormatType.php
@@ -14,8 +14,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class FullDateTimeFormatType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(ConfigResolverInterface $configResolver)
     {

--- a/src/lib/Form/Type/UserSettings/ShortDateTimeFormatType.php
+++ b/src/lib/Form/Type/UserSettings/ShortDateTimeFormatType.php
@@ -14,8 +14,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ShortDateTimeFormatType extends AbstractType
 {
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(ConfigResolverInterface $configResolver)
     {

--- a/src/lib/Invitation/DomainMapper.php
+++ b/src/lib/Invitation/DomainMapper.php
@@ -70,12 +70,12 @@ final class DomainMapper implements DomainMapperInterface
 
     private function loadUserGroup(int $userGroupId): UserGroup
     {
-        return $this->repository->sudo(fn () => $this->userService->loadUserGroup($userGroupId));
+        return $this->repository->sudo(fn (): \Ibexa\Contracts\Core\Repository\Values\User\UserGroup => $this->userService->loadUserGroup($userGroupId));
     }
 
     private function loadRole(int $roleId): Role
     {
-        return $this->repository->sudo(fn () => $this->roleService->loadRole($roleId));
+        return $this->repository->sudo(fn (): \Ibexa\Contracts\Core\Repository\Values\User\Role => $this->roleService->loadRole($roleId));
     }
 
     private function mapRoleLimitation(string $type, array $values): RoleLimitation

--- a/src/lib/Invitation/DomainMapper.php
+++ b/src/lib/Invitation/DomainMapper.php
@@ -70,12 +70,12 @@ final class DomainMapper implements DomainMapperInterface
 
     private function loadUserGroup(int $userGroupId): UserGroup
     {
-        return $this->repository->sudo(fn (): \Ibexa\Contracts\Core\Repository\Values\User\UserGroup => $this->userService->loadUserGroup($userGroupId));
+        return $this->repository->sudo(fn (): UserGroup => $this->userService->loadUserGroup($userGroupId));
     }
 
     private function loadRole(int $roleId): Role
     {
-        return $this->repository->sudo(fn (): \Ibexa\Contracts\Core\Repository\Values\User\Role => $this->roleService->loadRole($roleId));
+        return $this->repository->sudo(fn (): Role => $this->roleService->loadRole($roleId));
     }
 
     private function mapRoleLimitation(string $type, array $values): RoleLimitation

--- a/src/lib/Pagination/Pagerfanta/UserSettingsAdapter.php
+++ b/src/lib/Pagination/Pagerfanta/UserSettingsAdapter.php
@@ -16,8 +16,7 @@ use Pagerfanta\Adapter\AdapterInterface;
  */
 class UserSettingsAdapter implements AdapterInterface
 {
-    /** @var \Ibexa\User\UserSetting\UserSettingService */
-    private $userSettingService;
+    private UserSettingService $userSettingService;
 
     /**
      * @param \Ibexa\User\UserSetting\UserSettingService $userSettingService

--- a/src/lib/Permission/InvitationPolicyProvider.php
+++ b/src/lib/Permission/InvitationPolicyProvider.php
@@ -15,7 +15,7 @@ use JMS\TranslationBundle\Translation\TranslationContainerInterface;
 
 final class InvitationPolicyProvider implements PolicyProviderInterface, TranslationContainerInterface
 {
-    public function addPolicies(ConfigBuilderInterface $configBuilder)
+    public function addPolicies(ConfigBuilderInterface $configBuilder): void
     {
         $configBuilder->addConfig([
             'user' => [

--- a/src/lib/Permission/UserPermissionsLimitationType.php
+++ b/src/lib/Permission/UserPermissionsLimitationType.php
@@ -31,7 +31,7 @@ class UserPermissionsLimitationType extends AbstractPersistenceLimitationType im
      *
      * @param \Ibexa\Contracts\Core\Repository\Values\User\Limitation $limitationValue
      */
-    public function acceptValue(APILimitationValue $limitationValue)
+    public function acceptValue(APILimitationValue $limitationValue): void
     {
         if (!$limitationValue instanceof UserPermissionsLimitation) {
             throw new InvalidArgumentType(

--- a/src/lib/Templating/Twig/DateTimeExtension.php
+++ b/src/lib/Templating/Twig/DateTimeExtension.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 namespace Ibexa\User\Templating\Twig;
 
 use DateTimeImmutable;
+use DateTimeInterface;
 use Ibexa\User\UserSetting\DateTimeFormat\FormatterInterface;
 use Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer;
+use RuntimeException;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
@@ -117,12 +119,12 @@ class DateTimeExtension extends AbstractExtension
             $date = new DateTimeImmutable();
         }
 
-        if (\is_int($date)) {
+        if (is_int($date)) {
             $date = new DateTimeImmutable('@' . $date);
         }
 
-        if (!$date instanceof \DateTimeInterface) {
-            throw new \RuntimeException('The date argument passed to the format function must be an int or a DateTimeInterface');
+        if (!$date instanceof DateTimeInterface) {
+            throw new RuntimeException('The date argument passed to the format function must be an int or a DateTimeInterface');
         }
 
         return $formatter->format($date, $timezone);

--- a/src/lib/Templating/Twig/DateTimeExtension.php
+++ b/src/lib/Templating/Twig/DateTimeExtension.php
@@ -16,26 +16,19 @@ use Twig\TwigFilter;
 
 class DateTimeExtension extends AbstractExtension
 {
-    /** @var \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer */
-    private $dateTimeFormatSerializer;
+    private DateTimeFormatSerializer $dateTimeFormatSerializer;
 
-    /** @var \Ibexa\User\UserSetting\DateTimeFormat\FormatterInterface */
-    private $shortDateTimeFormatter;
+    private FormatterInterface $shortDateTimeFormatter;
 
-    /** @var \Ibexa\User\UserSetting\DateTimeFormat\FormatterInterface */
-    private $shortDateFormatter;
+    private FormatterInterface $shortDateFormatter;
 
-    /** @var \Ibexa\User\UserSetting\DateTimeFormat\FormatterInterface */
-    private $shortTimeFormatter;
+    private FormatterInterface $shortTimeFormatter;
 
-    /** @var \Ibexa\User\UserSetting\DateTimeFormat\FormatterInterface */
-    private $fullDateTimeFormatter;
+    private FormatterInterface $fullDateTimeFormatter;
 
-    /** @var \Ibexa\User\UserSetting\DateTimeFormat\FormatterInterface */
-    private $fullDateFormatter;
+    private FormatterInterface $fullDateFormatter;
 
-    /** @var \Ibexa\User\UserSetting\DateTimeFormat\FormatterInterface */
-    private $fullTimeFormatter;
+    private FormatterInterface $fullTimeFormatter;
 
     /**
      * @param \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer $dateTimeFormatSerializer
@@ -72,37 +65,37 @@ class DateTimeExtension extends AbstractExtension
         return [
             new TwigFilter(
                 'ibexa_short_datetime',
-                function ($date, $timezone = null) {
+                function ($date, $timezone = null): string {
                     return $this->format($this->shortDateTimeFormatter, $date, $timezone);
                 }
             ),
             new TwigFilter(
                 'ibexa_short_date',
-                function ($date, $timezone = null) {
+                function ($date, $timezone = null): string {
                     return $this->format($this->shortDateFormatter, $date, $timezone);
                 }
             ),
             new TwigFilter(
                 'ibexa_short_time',
-                function ($date, $timezone = null) {
+                function ($date, $timezone = null): string {
                     return $this->format($this->shortTimeFormatter, $date, $timezone);
                 }
             ),
             new TwigFilter(
                 'ibexa_full_datetime',
-                function ($date, $timezone = null) {
+                function ($date, $timezone = null): string {
                     return $this->format($this->fullDateTimeFormatter, $date, $timezone);
                 }
             ),
             new TwigFilter(
                 'ibexa_full_date',
-                function ($date, $timezone = null) {
+                function ($date, $timezone = null): string {
                     return $this->format($this->fullDateFormatter, $date, $timezone);
                 }
             ),
             new TwigFilter(
                 'ibexa_full_time',
-                function ($date, $timezone = null) {
+                function ($date, $timezone = null): string {
                     return $this->format($this->fullTimeFormatter, $date, $timezone);
                 }
             ),

--- a/src/lib/UserSetting/DateTimeFormat/AbstractDateTimeFormatterFactory.php
+++ b/src/lib/UserSetting/DateTimeFormat/AbstractDateTimeFormatterFactory.php
@@ -12,8 +12,7 @@ use Ibexa\User\UserSetting\UserSettingService;
 
 abstract class AbstractDateTimeFormatterFactory implements DateTimeFormatterFactoryInterface
 {
-    /** @var \Ibexa\User\UserSetting\UserSettingService */
-    protected $userSettingService;
+    protected UserSettingService $userSettingService;
 
     /**
      * @param \Ibexa\User\UserSetting\UserSettingService $userSettingService

--- a/src/lib/UserSetting/DateTimeFormat/Formatter.php
+++ b/src/lib/UserSetting/DateTimeFormat/Formatter.php
@@ -10,6 +10,7 @@ namespace Ibexa\User\UserSetting\DateTimeFormat;
 
 use DateTimeInterface;
 use IntlDateFormatter;
+use LogicException;
 
 class Formatter implements FormatterInterface
 {
@@ -36,7 +37,7 @@ class Formatter implements FormatterInterface
 
         $result = $this->formatter->format($datetime);
         if (false === $result) {
-            throw new \LogicException('Failed to format date time');
+            throw new LogicException('Failed to format date time');
         }
 
         if ($timezone) {

--- a/src/lib/UserSetting/DateTimeFormat/FullDateFormatterFactory.php
+++ b/src/lib/UserSetting/DateTimeFormat/FullDateFormatterFactory.php
@@ -13,8 +13,7 @@ use Ibexa\User\UserSetting\UserSettingService;
 
 class FullDateFormatterFactory extends AbstractDateTimeFormatterFactory implements DateTimeFormatterFactoryInterface
 {
-    /** @var \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer */
-    private $dateTimeFormatSerializer;
+    private DateTimeFormatSerializer $dateTimeFormatSerializer;
 
     /**
      * @param \Ibexa\User\UserSetting\UserSettingService $userSettingService

--- a/src/lib/UserSetting/DateTimeFormat/FullDateTimeFormatterFactory.php
+++ b/src/lib/UserSetting/DateTimeFormat/FullDateTimeFormatterFactory.php
@@ -13,8 +13,7 @@ use Ibexa\User\UserSetting\UserSettingService;
 
 class FullDateTimeFormatterFactory extends AbstractDateTimeFormatterFactory implements DateTimeFormatterFactoryInterface
 {
-    /** @var \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer */
-    private $dateTimeFormatSerializer;
+    private DateTimeFormatSerializer $dateTimeFormatSerializer;
 
     /**
      * @param \Ibexa\User\UserSetting\UserSettingService $userSettingService

--- a/src/lib/UserSetting/DateTimeFormat/FullTimeFormatterFactory.php
+++ b/src/lib/UserSetting/DateTimeFormat/FullTimeFormatterFactory.php
@@ -13,8 +13,7 @@ use Ibexa\User\UserSetting\UserSettingService;
 
 class FullTimeFormatterFactory extends AbstractDateTimeFormatterFactory implements DateTimeFormatterFactoryInterface
 {
-    /** @var \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer */
-    private $dateTimeFormatSerializer;
+    private DateTimeFormatSerializer $dateTimeFormatSerializer;
 
     /**
      * @param \Ibexa\User\UserSetting\UserSettingService $userSettingService

--- a/src/lib/UserSetting/DateTimeFormat/ShortDateFormatterFactory.php
+++ b/src/lib/UserSetting/DateTimeFormat/ShortDateFormatterFactory.php
@@ -13,8 +13,7 @@ use Ibexa\User\UserSetting\UserSettingService;
 
 class ShortDateFormatterFactory extends AbstractDateTimeFormatterFactory implements DateTimeFormatterFactoryInterface
 {
-    /** @var \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer */
-    private $dateTimeFormatSerializer;
+    private DateTimeFormatSerializer $dateTimeFormatSerializer;
 
     /**
      * @param \Ibexa\User\UserSetting\UserSettingService $userSettingService

--- a/src/lib/UserSetting/DateTimeFormat/ShortDateTimeFormatterFactory.php
+++ b/src/lib/UserSetting/DateTimeFormat/ShortDateTimeFormatterFactory.php
@@ -13,8 +13,7 @@ use Ibexa\User\UserSetting\UserSettingService;
 
 class ShortDateTimeFormatterFactory extends AbstractDateTimeFormatterFactory implements DateTimeFormatterFactoryInterface
 {
-    /** @var \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer */
-    private $dateTimeFormatSerializer;
+    private DateTimeFormatSerializer $dateTimeFormatSerializer;
 
     /**
      * @param \Ibexa\User\UserSetting\UserSettingService $userSettingService

--- a/src/lib/UserSetting/DateTimeFormat/ShortTimeFormatterFactory.php
+++ b/src/lib/UserSetting/DateTimeFormat/ShortTimeFormatterFactory.php
@@ -13,8 +13,7 @@ use Ibexa\User\UserSetting\UserSettingService;
 
 class ShortTimeFormatterFactory extends AbstractDateTimeFormatterFactory implements DateTimeFormatterFactoryInterface
 {
-    /** @var \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer */
-    private $dateTimeFormatSerializer;
+    private DateTimeFormatSerializer $dateTimeFormatSerializer;
 
     /**
      * @param \Ibexa\User\UserSetting\UserSettingService $userSettingService

--- a/src/lib/UserSetting/Setting/AbstractDateTimeFormat.php
+++ b/src/lib/UserSetting/Setting/AbstractDateTimeFormat.php
@@ -15,11 +15,10 @@ use Ibexa\User\UserSetting\DateTimeFormat\FormatterInterface;
 
 abstract class AbstractDateTimeFormat implements ValueDefinitionInterface, FormMapperInterface
 {
-    /** @var \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer */
-    protected $serializer;
+    protected DateTimeFormatSerializer $serializer;
 
     /** @var \Ibexa\User\UserSetting\DateTimeFormat\Formatter|null */
-    protected $formatter;
+    protected FormatterInterface $formatter;
 
     /**
      * @param \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer $serializer

--- a/src/lib/UserSetting/Setting/CharacterCounter.php
+++ b/src/lib/UserSetting/Setting/CharacterCounter.php
@@ -21,8 +21,7 @@ class CharacterCounter implements ValueDefinitionInterface, FormMapperInterface
     public const ENABLED_OPTION = 'enabled';
     public const DISABLED_OPTION = 'disabled';
 
-    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
-    private $translator;
+    private TranslatorInterface $translator;
 
     /**
      * @param \Symfony\Contracts\Translation\TranslatorInterface $translator

--- a/src/lib/UserSetting/Setting/DateTimeFormatSerializer.php
+++ b/src/lib/UserSetting/Setting/DateTimeFormatSerializer.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\User\UserSetting\Setting;
 
 use Ibexa\User\UserSetting\Setting\Value\DateTimeFormat;
+use function is_array;
 
 final class DateTimeFormatSerializer
 {
@@ -16,7 +17,7 @@ final class DateTimeFormatSerializer
     {
         $value = json_decode($value, true);
 
-        if (!\is_array($value)) {
+        if (!is_array($value)) {
             return null;
         }
 

--- a/src/lib/UserSetting/Setting/FullDateTimeFormat.php
+++ b/src/lib/UserSetting/Setting/FullDateTimeFormat.php
@@ -20,11 +20,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FullDateTimeFormat extends AbstractDateTimeFormat
 {
-    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
-    private $translator;
+    private TranslatorInterface $translator;
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     /**
      * @param \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer $serializer

--- a/src/lib/UserSetting/Setting/Language.php
+++ b/src/lib/UserSetting/Setting/Language.php
@@ -19,14 +19,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class Language implements ValueDefinitionInterface, FormMapperInterface
 {
-    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
-    private $translator;
+    private TranslatorInterface $translator;
 
-    /** @var \Ibexa\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface */
-    private $userLanguagePreferenceProvider;
+    private UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider;
 
-    /** @var \Ibexa\User\Form\ChoiceList\Loader\AvailableLocaleChoiceLoader */
-    private $availableLocaleChoiceLoader;
+    private AvailableLocaleChoiceLoader $availableLocaleChoiceLoader;
 
     /**
      * @param \Symfony\Contracts\Translation\TranslatorInterface $translator

--- a/src/lib/UserSetting/Setting/ShortDateTimeFormat.php
+++ b/src/lib/UserSetting/Setting/ShortDateTimeFormat.php
@@ -20,11 +20,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ShortDateTimeFormat extends AbstractDateTimeFormat
 {
-    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
-    private $translator;
+    private TranslatorInterface $translator;
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     /**
      * @param \Ibexa\User\UserSetting\Setting\DateTimeFormatSerializer $serializer

--- a/src/lib/UserSetting/Setting/SubitemsLimit.php
+++ b/src/lib/UserSetting/Setting/SubitemsLimit.php
@@ -18,11 +18,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SubitemsLimit implements ValueDefinitionInterface, FormMapperInterface
 {
-    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
-    private $translator;
+    private TranslatorInterface $translator;
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     public function __construct(TranslatorInterface $translator, ConfigResolverInterface $configResolver)
     {

--- a/src/lib/UserSetting/Setting/Timezone.php
+++ b/src/lib/UserSetting/Setting/Timezone.php
@@ -17,8 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class Timezone implements ValueDefinitionInterface, FormMapperInterface
 {
-    /** @var \Symfony\Contracts\Translation\TranslatorInterface */
-    private $translator;
+    private TranslatorInterface $translator;
 
     /**
      * @param \Symfony\Contracts\Translation\TranslatorInterface $translator

--- a/src/lib/UserSetting/Setting/Value/DateTimeFormat.php
+++ b/src/lib/UserSetting/Setting/Value/DateTimeFormat.php
@@ -10,11 +10,9 @@ namespace Ibexa\User\UserSetting\Setting\Value;
 
 final class DateTimeFormat
 {
-    /** @var string|null */
-    private $dateFormat;
+    private ?string $dateFormat;
 
-    /** @var string|null */
-    private $timeFormat;
+    private ?string $timeFormat;
 
     /**
      * @param string|null $dateFormat
@@ -34,7 +32,7 @@ final class DateTimeFormat
         return $this->dateFormat;
     }
 
-    public function setDateFormat(?string $dateFormat)
+    public function setDateFormat(?string $dateFormat): void
     {
         $this->dateFormat = $dateFormat;
     }
@@ -47,7 +45,7 @@ final class DateTimeFormat
         return $this->timeFormat;
     }
 
-    public function setTimeFormat(?string $timeFormat)
+    public function setTimeFormat(?string $timeFormat): void
     {
         $this->timeFormat = $timeFormat;
     }

--- a/src/lib/UserSetting/UserSettingArrayAccessor.php
+++ b/src/lib/UserSetting/UserSettingArrayAccessor.php
@@ -16,8 +16,7 @@ use Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException;
  */
 class UserSettingArrayAccessor implements ArrayAccess
 {
-    /** @var \Ibexa\User\UserSetting\UserSettingService */
-    protected $userSettingService;
+    protected UserSettingService $userSettingService;
 
     /**
      * @param \Ibexa\User\UserSetting\UserSettingService $userSettingService

--- a/src/lib/UserSetting/UserSettingService.php
+++ b/src/lib/UserSetting/UserSettingService.php
@@ -92,7 +92,7 @@ class UserSettingService
     {
         $values = $this->valueRegistry->getValueDefinitions();
         /** @var \Ibexa\Contracts\User\UserSetting\ValueDefinitionInterface[] $slice */
-        $slice = \array_slice($values, $offset, $limit, true);
+        $slice = array_slice($values, $offset, $limit, true);
 
         $userPreferences = [];
         foreach ($slice as $identifier => $userSettingDefinition) {

--- a/src/lib/UserSetting/UserSettingService.php
+++ b/src/lib/UserSetting/UserSettingService.php
@@ -19,11 +19,9 @@ use Ibexa\Contracts\User\UserSetting\ValueDefinitionInterface;
  */
 class UserSettingService
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserPreferenceService */
-    protected $userPreferenceService;
+    protected UserPreferenceService $userPreferenceService;
 
-    /** @var \Ibexa\User\UserSetting\ValueDefinitionRegistry */
-    protected $valueRegistry;
+    protected ValueDefinitionRegistry $valueRegistry;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\UserPreferenceService $userPreferenceService
@@ -191,7 +189,7 @@ class UserSettingService
         return $userPreferenceValue;
     }
 
-    public function countGroupedUserSettings()
+    public function countGroupedUserSettings(): int
     {
         return $this->valueRegistry->countValueDefinitionGroups();
     }

--- a/src/lib/UserSetting/ValueDefinitionGroupRegistryEntry.php
+++ b/src/lib/UserSetting/ValueDefinitionGroupRegistryEntry.php
@@ -11,12 +11,13 @@ namespace Ibexa\User\UserSetting;
 use ArrayIterator;
 use Ibexa\Contracts\User\UserSetting\ValueDefinitionGroupInterface;
 use Ibexa\Contracts\User\UserSetting\ValueDefinitionInterface;
+use IteratorAggregate;
 use Traversable;
 
 /**
  * @internal
  */
-final class ValueDefinitionGroupRegistryEntry implements \IteratorAggregate
+final class ValueDefinitionGroupRegistryEntry implements IteratorAggregate
 {
     private ValueDefinitionGroupInterface $definition;
 

--- a/src/lib/UserSetting/ValueDefinitionRegistry.php
+++ b/src/lib/UserSetting/ValueDefinitionRegistry.php
@@ -19,7 +19,7 @@ use Ibexa\User\UserSetting\Group\CustomGroup;
 class ValueDefinitionRegistry
 {
     /** @var \Ibexa\Contracts\User\UserSetting\ValueDefinitionInterface[] */
-    protected $valueDefinitions;
+    protected array $valueDefinitions;
 
     /** @var \Ibexa\Contracts\User\UserSetting\ValueDefinitionGroupInterface[] */
     protected $groupedDefinitions;

--- a/src/lib/UserSetting/ValueDefinitionRegistry.php
+++ b/src/lib/UserSetting/ValueDefinitionRegistry.php
@@ -119,11 +119,11 @@ class ValueDefinitionRegistry
      */
     public function countValueDefinitions(): int
     {
-        return \count($this->valueDefinitions);
+        return count($this->valueDefinitions);
     }
 
     public function countValueDefinitionGroups(): int
     {
-        return \count($this->groupedDefinitions);
+        return count($this->groupedDefinitions);
     }
 }

--- a/src/lib/UserSetting/ValueDefinitionRegistryEntry.php
+++ b/src/lib/UserSetting/ValueDefinitionRegistryEntry.php
@@ -15,11 +15,9 @@ use Ibexa\Contracts\User\UserSetting\ValueDefinitionInterface;
  */
 final class ValueDefinitionRegistryEntry
 {
-    /** @var \Ibexa\Contracts\User\UserSetting\ValueDefinitionInterface */
-    private $definition;
+    private ValueDefinitionInterface $definition;
 
-    /** @var int */
-    private $priority;
+    private int $priority;
 
     /**
      * @param \Ibexa\Contracts\User\UserSetting\ValueDefinitionInterface $definition

--- a/src/lib/Validator/Constraints/EmailInvitationValidator.php
+++ b/src/lib/Validator/Constraints/EmailInvitationValidator.php
@@ -28,7 +28,7 @@ class EmailInvitationValidator extends ConstraintValidator
      * @param string $email The value that should be validated
      * @param \Symfony\Component\Validator\Constraint $constraint The constraint for the validation
      */
-    public function validate($email, Constraint $constraint)
+    public function validate($email, Constraint $constraint): void
     {
         try {
             $this->userService->loadUserByEmail($email);

--- a/src/lib/Validator/Constraints/PasswordValidator.php
+++ b/src/lib/Validator/Constraints/PasswordValidator.php
@@ -30,7 +30,7 @@ class PasswordValidator extends ConstraintValidator
      */
     public function validate(mixed $value, Constraint $constraint): void
     {
-        if (!\is_string($value) || empty($value)) {
+        if (!is_string($value) || empty($value)) {
             return;
         }
 

--- a/src/lib/Validator/Constraints/UserPasswordValidator.php
+++ b/src/lib/Validator/Constraints/UserPasswordValidator.php
@@ -20,11 +20,9 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  */
 class UserPasswordValidator extends ConstraintValidator
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserService */
-    private $userService;
+    private UserService $userService;
 
-    /** @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface */
-    private $tokenStorage;
+    private TokenStorageInterface $tokenStorage;
 
     /**
      * @param \Ibexa\Contracts\Core\Repository\UserService $userService
@@ -42,7 +40,7 @@ class UserPasswordValidator extends ConstraintValidator
      * @param string $password The password that should be validated
      * @param \Symfony\Component\Validator\Constraint|\Ibexa\User\Validator\Constraints\UserPassword $constraint The constraint for the validation
      */
-    public function validate($password, Constraint $constraint)
+    public function validate($password, Constraint $constraint): void
     {
         if (null === $password || '' === $password) {
             $this->context->addViolation($constraint->message);

--- a/src/lib/View/UserSettings/Matcher/Identifier.php
+++ b/src/lib/View/UserSettings/Matcher/Identifier.php
@@ -18,7 +18,7 @@ use Ibexa\User\View\UserSettings\UpdateView;
 class Identifier implements ViewMatcherInterface
 {
     /** @var string[] */
-    private $identifiers = [];
+    private array $identifiers = [];
 
     /**
      * {@inheritdoc}

--- a/src/lib/View/UserSettings/UpdateViewBuilder.php
+++ b/src/lib/View/UserSettings/UpdateViewBuilder.php
@@ -15,14 +15,11 @@ use Ibexa\User\UserSetting\UserSettingService;
 
 class UpdateViewBuilder implements ViewBuilder
 {
-    /** @var \Ibexa\User\UserSetting\UserSettingService */
-    private $userSettingService;
+    private UserSettingService $userSettingService;
 
-    /** @var \Ibexa\Core\MVC\Symfony\View\Configurator */
-    private $viewConfigurator;
+    private Configurator $viewConfigurator;
 
-    /** @var \Ibexa\Core\MVC\Symfony\View\ParametersInjector */
-    private $viewParametersInjector;
+    private ParametersInjector $viewParametersInjector;
 
     /**
      * @param \Ibexa\User\UserSetting\UserSettingService $userSettingService

--- a/src/lib/View/UserSettings/UpdateViewProvider.php
+++ b/src/lib/View/UserSettings/UpdateViewProvider.php
@@ -56,7 +56,7 @@ class UpdateViewProvider implements ViewProvider
             $view->setControllerReference(new ControllerReference($viewConfig['controller']));
         }
 
-        if (isset($viewConfig['params']) && \is_array($viewConfig['params'])) {
+        if (isset($viewConfig['params']) && is_array($viewConfig['params'])) {
             $view->addParameters($viewConfig['params']);
         }
 

--- a/src/lib/View/UserSettings/UpdateViewProvider.php
+++ b/src/lib/View/UserSettings/UpdateViewProvider.php
@@ -15,8 +15,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 class UpdateViewProvider implements ViewProvider
 {
-    /** @var \Ibexa\Core\MVC\Symfony\Matcher\MatcherFactoryInterface */
-    protected $matcherFactory;
+    protected MatcherFactoryInterface $matcherFactory;
 
     /**
      * @param \Ibexa\Core\MVC\Symfony\Matcher\MatcherFactoryInterface $matcherFactory

--- a/tests/bundle/DependencyInjection/Configuration/Parser/ChangePasswordTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/ChangePasswordTest.php
@@ -51,7 +51,7 @@ final class ChangePasswordTest extends AbstractParserTestCase
         );
     }
 
-    public function testOverwrittenConfig()
+    public function testOverwrittenConfig(): void
     {
         $this->load([
             'system' => [

--- a/tests/bundle/DependencyInjection/Configuration/Parser/ForgotPasswordTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/ForgotPasswordTest.php
@@ -51,7 +51,7 @@ final class ForgotPasswordTest extends AbstractParserTestCase
         );
     }
 
-    public function testOverwrittenConfig()
+    public function testOverwrittenConfig(): void
     {
         $this->load([
             'system' => [

--- a/tests/bundle/DependencyInjection/Configuration/Parser/ResetPasswordTest.php
+++ b/tests/bundle/DependencyInjection/Configuration/Parser/ResetPasswordTest.php
@@ -51,7 +51,7 @@ final class ResetPasswordTest extends AbstractParserTestCase
         );
     }
 
-    public function testOverwrittenConfig()
+    public function testOverwrittenConfig(): void
     {
         $this->load([
             'system' => [

--- a/tests/integration/Invitation/InvitationServiceTest.php
+++ b/tests/integration/Invitation/InvitationServiceTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Integration\User\Invitation;
 
+use DateTime;
 use Ibexa\Contracts\Core\Repository\RoleService;
 use Ibexa\Contracts\Core\Repository\UserService;
 use Ibexa\Contracts\User\Invitation\Exception\InvitationAlreadyExistsException;
@@ -38,7 +39,7 @@ final class InvitationServiceTest extends IbexaKernelTestCase
 
     public function testCreateInvitation(): void
     {
-        $now = (new \DateTime())->getTimestamp();
+        $now = (new DateTime())->getTimestamp();
         $invitation = $this->invitationService->createInvitation(
             new InvitationCreateStruct(
                 'thisisjustatest@ibexa.co',

--- a/tests/lib/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoaderTest.php
+++ b/tests/lib/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoaderTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\User\Form\Type\ChoiceList\Loader;
 
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 use Ibexa\User\Form\ChoiceList\Loader\AvailableLocaleChoiceLoader;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -18,13 +19,13 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class AvailableLocaleChoiceLoaderTest extends TestCase
 {
     /** @var \Symfony\Component\Validator\Validator\ValidatorInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $validator;
+    private MockObject $validator;
 
     /** @var \Symfony\Component\Validator\ConstraintViolationInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $constraintViolation;
+    private MockObject $constraintViolation;
 
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $configResolver;
+    private MockObject $configResolver;
 
     protected function setUp(): void
     {
@@ -49,7 +50,7 @@ class AvailableLocaleChoiceLoaderTest extends TestCase
     ): void {
         $this->validator
             ->method('validate')
-            ->willReturnCallback(function ($locale) {
+            ->willReturnCallback(function ($locale): ConstraintViolationList {
                 return $locale === 'foo_BAR' ? new ConstraintViolationList([$this->constraintViolation]) : new ConstraintViolationList();
             });
 

--- a/tests/lib/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoaderTest.php
+++ b/tests/lib/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoaderTest.php
@@ -18,14 +18,11 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class AvailableLocaleChoiceLoaderTest extends TestCase
 {
-    /** @var \Symfony\Component\Validator\Validator\ValidatorInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $validator;
+    private ValidatorInterface&MockObject $validator;
 
-    /** @var \Symfony\Component\Validator\ConstraintViolationInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $constraintViolation;
+    private ConstraintViolationInterface&MockObject $constraintViolation;
 
-    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $configResolver;
+    private ConfigResolverInterface&MockObject $configResolver;
 
     protected function setUp(): void
     {

--- a/tests/lib/Invitation/InvitationServiceTest.php
+++ b/tests/lib/Invitation/InvitationServiceTest.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\User\Invitation;
 
+use DateInterval;
+use DateTime;
 use Ibexa\Contracts\Core\HashGenerator;
 use Ibexa\Contracts\Core\Persistence\TransactionHandler;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
@@ -81,7 +83,7 @@ class InvitationServiceTest extends TestCase
                 new Invitation(
                     'test@ibexa.co',
                     'random_hash',
-                    (new \DateTime())->sub(new \DateInterval('PT2H')),
+                    (new DateTime())->sub(new DateInterval('PT2H')),
                     'admin',
                     false,
                 ),
@@ -92,7 +94,7 @@ class InvitationServiceTest extends TestCase
                 new Invitation(
                     'test@ibexa.co',
                     'random_hash',
-                    (new \DateTime())->sub(new \DateInterval('P3D')),
+                    (new DateTime())->sub(new DateInterval('P3D')),
                     'admin',
                     false,
                 ),
@@ -103,7 +105,7 @@ class InvitationServiceTest extends TestCase
                 new Invitation(
                     'test@ibexa.co',
                     'random_hash',
-                    (new \DateTime())->sub(new \DateInterval('PT2H')),
+                    (new DateTime())->sub(new DateInterval('PT2H')),
                     'admin',
                     false,
                 ),
@@ -114,7 +116,7 @@ class InvitationServiceTest extends TestCase
                 new Invitation(
                     'test@ibexa.co',
                     'random_hash',
-                    (new \DateTime())->sub(new \DateInterval('PT2H')),
+                    (new DateTime())->sub(new DateInterval('PT2H')),
                     'admin',
                     true,
                 ),

--- a/tests/lib/Permission/UserPermissionsLimitationTypeTest.php
+++ b/tests/lib/Permission/UserPermissionsLimitationTypeTest.php
@@ -178,7 +178,7 @@ class UserPermissionsLimitationTypeTest extends Base
         self::assertCount($errorCount, $validationErrors);
     }
 
-    public function providerForTestValidateError()
+    public function providerForTestValidateError(): array
     {
         return [
             [
@@ -230,7 +230,7 @@ class UserPermissionsLimitationTypeTest extends Base
         self::assertEquals($expected, $value);
     }
 
-    public function providerForTestEvaluate()
+    public function providerForTestEvaluate(): array
     {
         return [
             'valid_role_limitation' => [

--- a/tests/lib/UserSetting/ValueDefinitionRegistryTest.php
+++ b/tests/lib/UserSetting/ValueDefinitionRegistryTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class ValueDefinitionRegistryTest extends TestCase
 {
-    public function testGetValueDefinitions()
+    public function testGetValueDefinitions(): void
     {
         $definitions = [
             'foo' => $this->createMock(ValueDefinitionInterface::class),
@@ -27,7 +27,7 @@ class ValueDefinitionRegistryTest extends TestCase
         self::assertEquals($definitions, $registry->getValueDefinitions());
     }
 
-    public function testAddValueDefinition()
+    public function testAddValueDefinition(): void
     {
         $foo = $this->createMock(ValueDefinitionInterface::class);
 
@@ -37,7 +37,7 @@ class ValueDefinitionRegistryTest extends TestCase
         self::assertEquals(['foo' => $foo], $registry->getValueDefinitions());
     }
 
-    public function testHasValueDefinition()
+    public function testHasValueDefinition(): void
     {
         $registry = new ValueDefinitionRegistry([
             'foo' => $this->createMock(ValueDefinitionInterface::class),
@@ -47,7 +47,7 @@ class ValueDefinitionRegistryTest extends TestCase
         self::assertFalse($registry->hasValueDefinition('bar'));
     }
 
-    public function testGetValueDefinition()
+    public function testGetValueDefinition(): void
     {
         $foo = $this->createMock(ValueDefinitionInterface::class);
 
@@ -58,7 +58,7 @@ class ValueDefinitionRegistryTest extends TestCase
         self::assertEquals($foo, $registry->getValueDefinition('foo'));
     }
 
-    public function testCountValueDefinitions()
+    public function testCountValueDefinitions(): void
     {
         $definitions = [
             'foo' => $this->createMock(ValueDefinitionInterface::class),
@@ -70,7 +70,7 @@ class ValueDefinitionRegistryTest extends TestCase
         self::assertEquals(2, $registry->countValueDefinitions());
     }
 
-    public function testCountValueDefinitionsWithEmptyRegistry()
+    public function testCountValueDefinitionsWithEmptyRegistry(): void
     {
         $registry = new ValueDefinitionRegistry([]);
 

--- a/tests/lib/Validator/Constraint/PasswordTest.php
+++ b/tests/lib/Validator/Constraint/PasswordTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 class PasswordTest extends TestCase
 {
     /** @var \Ibexa\User\Validator\Constraints\Password */
-    private $constraint;
+    private Password $constraint;
 
     protected function setUp(): void
     {

--- a/tests/lib/Validator/Constraint/PasswordTest.php
+++ b/tests/lib/Validator/Constraint/PasswordTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\TestCase;
 
 class PasswordTest extends TestCase
 {
-    /** @var \Ibexa\User\Validator\Constraints\Password */
     private Password $constraint;
 
     protected function setUp(): void

--- a/tests/lib/Validator/Constraint/PasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraint/PasswordValidatorTest.php
@@ -17,18 +17,16 @@ use Ibexa\User\Validator\Constraints\Password;
 use Ibexa\User\Validator\Constraints\PasswordValidator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 class PasswordValidatorTest extends TestCase
 {
-    /** @var \Ibexa\Contracts\Core\Repository\UserService|\PHPUnit\Framework\MockObject\MockObject */
-    private MockObject $userService;
+    private UserService&MockObject $userService;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\Validator\Context\ExecutionContextInterface */
-    private MockObject $executionContext;
+    private ExecutionContextInterface&MockObject $executionContext;
 
-    /** @var \Ibexa\User\Validator\Constraints\PasswordValidator */
     private PasswordValidator $validator;
 
     protected function setUp(): void
@@ -42,7 +40,7 @@ class PasswordValidatorTest extends TestCase
     /**
      * @dataProvider dataProviderForValidateNotSupportedValueType
      */
-    public function testValidateShouldBeSkipped(\stdClass|string|null $value): void
+    public function testValidateShouldBeSkipped(mixed $value): void
     {
         $this->userService
             ->expects(self::never())
@@ -145,7 +143,7 @@ class PasswordValidatorTest extends TestCase
     public function dataProviderForValidateNotSupportedValueType(): array
     {
         return [
-            [new \stdClass()],
+            [new stdClass()],
             [null],
             [''],
         ];

--- a/tests/lib/Validator/Constraint/PasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraint/PasswordValidatorTest.php
@@ -15,6 +15,7 @@ use Ibexa\Contracts\Core\Repository\Values\User\User;
 use Ibexa\Core\FieldType\ValidationError;
 use Ibexa\User\Validator\Constraints\Password;
 use Ibexa\User\Validator\Constraints\PasswordValidator;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
@@ -22,13 +23,13 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 class PasswordValidatorTest extends TestCase
 {
     /** @var \Ibexa\Contracts\Core\Repository\UserService|\PHPUnit\Framework\MockObject\MockObject */
-    private $userService;
+    private MockObject $userService;
 
     /** @var \PHPUnit\Framework\MockObject\MockObject|\Symfony\Component\Validator\Context\ExecutionContextInterface */
-    private $executionContext;
+    private MockObject $executionContext;
 
     /** @var \Ibexa\User\Validator\Constraints\PasswordValidator */
-    private $validator;
+    private PasswordValidator $validator;
 
     protected function setUp(): void
     {
@@ -41,7 +42,7 @@ class PasswordValidatorTest extends TestCase
     /**
      * @dataProvider dataProviderForValidateNotSupportedValueType
      */
-    public function testValidateShouldBeSkipped($value): void
+    public function testValidateShouldBeSkipped(\stdClass|string|null $value): void
     {
         $this->userService
             ->expects(self::never())

--- a/tests/lib/Validator/Constraint/UserPasswordTest.php
+++ b/tests/lib/Validator/Constraint/UserPasswordTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 
 class UserPasswordTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $constraint = new UserPassword();
         self::assertSame('ezplatform.change_user_password.not_match', $constraint->message);

--- a/tests/lib/Validator/Constraint/UserPasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraint/UserPasswordValidatorTest.php
@@ -22,24 +22,12 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 class UserPasswordValidatorTest extends TestCase
 {
-    /**
-     * @var \Ibexa\Contracts\Core\Repository\UserService|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $userService;
+    private UserService&MockObject $userService;
 
-    /**
-     * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $tokenStorage;
+    private TokenStorageInterface&MockObject $tokenStorage;
 
-    /**
-     * @var \Symfony\Component\Validator\Context\ExecutionContextInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private MockObject $executionContext;
+    private ExecutionContextInterface&MockObject $executionContext;
 
-    /**
-     * @var \Ibexa\User\Validator\Constraints\UserPasswordValidator
-     */
     private UserPasswordValidator $validator;
 
     protected function setUp(): void

--- a/tests/lib/Validator/Constraint/UserPasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraint/UserPasswordValidatorTest.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\Values\User\User as APIUser;
 use Ibexa\Core\MVC\Symfony\Security\ReferenceUserInterface;
 use Ibexa\User\Validator\Constraints\UserPassword;
 use Ibexa\User\Validator\Constraints\UserPasswordValidator;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -24,22 +25,22 @@ class UserPasswordValidatorTest extends TestCase
     /**
      * @var \Ibexa\Contracts\Core\Repository\UserService|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $userService;
+    private MockObject $userService;
 
     /**
      * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $tokenStorage;
+    private MockObject $tokenStorage;
 
     /**
      * @var \Symfony\Component\Validator\Context\ExecutionContextInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $executionContext;
+    private MockObject $executionContext;
 
     /**
      * @var \Ibexa\User\Validator\Constraints\UserPasswordValidator
      */
-    private $validator;
+    private UserPasswordValidator $validator;
 
     protected function setUp(): void
     {
@@ -55,7 +56,7 @@ class UserPasswordValidatorTest extends TestCase
      *
      * @param string|null $value
      */
-    public function testEmptyValueType($value)
+    public function testEmptyValueType(?string $value): void
     {
         $this->userService
             ->expects(self::never())
@@ -78,7 +79,7 @@ class UserPasswordValidatorTest extends TestCase
         ];
     }
 
-    public function testValid()
+    public function testValid(): void
     {
         $apiUser = $this->getMockForAbstractClass(APIUser::class, [], '', true, true, true, ['__get']);
         $apiUser->method('__get')->with(self::equalTo('login'))->willReturn('login');
@@ -98,7 +99,7 @@ class UserPasswordValidatorTest extends TestCase
         $this->validator->validate('password', new UserPassword());
     }
 
-    public function testInvalid()
+    public function testInvalid(): void
     {
         $apiUser = $this->getMockForAbstractClass(APIUser::class, [], '', true, true, true, ['__get']);
         $apiUser->method('__get')->with(self::equalTo('login'))->willReturn('login');


### PR DESCRIPTION
> [!CAUTION]
> These changes are volatile and - in some repositories - extensive, so they need to be carefully reviewed before merging.

| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Description:

Added missing strict type hints using `\Rector\Set\ValueObject\SetList::TYPE_DECLARATION` set.
Additionally FQCNs have been imported for every affected file using PHP CS Fixer, in some cases they might override unrelated lines.

#### For QA:

Regression tests.
