### PR TITLE
IBX-8552: Added option to configure registration user group by user group content remote id

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1441,18 +1441,6 @@ parameters:
 			path: tests/lib/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoaderTest.php
 
 		-
-			message: '#^Access to an undefined property Ibexa\\Tests\\User\\Invitation\\InvitationServiceTest\:\:\$configResolver\.$#'
-			identifier: property.notFound
-			count: 2
-			path: tests/lib/Invitation/InvitationServiceTest.php
-
-		-
-			message: '#^Access to an undefined property Ibexa\\Tests\\User\\Invitation\\InvitationServiceTest\:\:\$siteAccessService\.$#'
-			identifier: property.notFound
-			count: 2
-			path: tests/lib/Invitation/InvitationServiceTest.php
-
-		-
 			message: '#^Method Ibexa\\Tests\\User\\Invitation\\InvitationServiceTest\:\:invitationProvider\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
@@ -34,7 +34,7 @@ class UserRegistration extends AbstractParser
                         ->defaultValue(11)
                     ->end()
                     ->scalarNode('group_remote_id')
-                        ->info('Content Remote id of the user group where users who register are created - takes precedence over group_id if set.')
+                        ->info('Content remote id of the user group where users who register are created - takes precedence over group_id if set.')
                         ->defaultNull()
                     ->end()
                     ->arrayNode('templates')

--- a/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
@@ -33,6 +33,10 @@ class UserRegistration extends AbstractParser
                         ->info('Content id of the user group where users who register are created.')
                         ->defaultValue(11)
                     ->end()
+                    ->scalarNode('group_remote_id')
+                        ->info('Content Remote id of the user group where users who register are created - takes precedence over group_id if set.')
+                        ->defaultNull()
+                    ->end()
                     ->arrayNode('templates')
                         ->info('User registration templates.')
                         ->children()
@@ -78,6 +82,14 @@ class UserRegistration extends AbstractParser
                 'user_registration.group_id',
                 $currentScope,
                 $settings['group_id']
+            );
+        }
+
+        if (!empty($settings['group_remote_id'])) {
+            $contextualizer->setContextualParameter(
+                'user_registration.group_remote_id',
+                $currentScope,
+                $settings['group_remote_id']
             );
         }
 

--- a/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
@@ -32,6 +32,7 @@ class UserRegistration extends AbstractParser
                     ->scalarNode('group_id')
                         ->info('Content id of the user group where users who register are created.')
                         ->defaultValue(11)
+                        ->setDeprecated('ibexa/user', '4.6', 'The child node "%node%" at path "%path%" is deprecated, use group_remote_id instead.')
                     ->end()
                     ->scalarNode('group_remote_id')
                         ->info('Content remote id of the user group where users who register are created - takes precedence over group_id if set.')

--- a/src/contracts/Notification/UserPasswordReset.php
+++ b/src/contracts/Notification/UserPasswordReset.php
@@ -17,9 +17,7 @@ use Symfony\Component\Notifier\Notification\SmsNotificationInterface;
 use Symfony\Component\Notifier\Recipient\EmailRecipientInterface;
 use Symfony\Component\Notifier\Recipient\SmsRecipientInterface;
 
-final class UserPasswordReset
-extends Notification
-implements EmailNotificationInterface, SmsNotificationInterface, UserAwareNotificationInterface
+final class UserPasswordReset extends Notification implements EmailNotificationInterface, SmsNotificationInterface, UserAwareNotificationInterface
 {
     private User $user;
 

--- a/src/contracts/Notification/UserRegister.php
+++ b/src/contracts/Notification/UserRegister.php
@@ -17,9 +17,7 @@ use Symfony\Component\Notifier\Notification\SmsNotificationInterface;
 use Symfony\Component\Notifier\Recipient\EmailRecipientInterface;
 use Symfony\Component\Notifier\Recipient\SmsRecipientInterface;
 
-final class UserRegister
-extends Notification
-implements EmailNotificationInterface, SmsNotificationInterface, UserAwareNotificationInterface
+final class UserRegister extends Notification implements EmailNotificationInterface, SmsNotificationInterface, UserAwareNotificationInterface
 {
     private User $user;
 

--- a/src/lib/ConfigResolver/ConfigurableRegistrationGroupLoader.php
+++ b/src/lib/ConfigResolver/ConfigurableRegistrationGroupLoader.php
@@ -30,6 +30,16 @@ class ConfigurableRegistrationGroupLoader implements RegistrationGroupLoader
 
     public function loadGroup()
     {
+        if ($this->configResolver->hasParameter('user_registration.group_remote_id')) {
+            return $this->repository->sudo(function (Repository $repository) {
+                return $repository
+                    ->getUserService()
+                    ->loadUserGroupByRemoteId(
+                        $this->configResolver->getParameter('user_registration.group_remote_id')
+                    );
+            });
+        }
+
         return $this->repository->sudo(function (Repository $repository) {
             return $repository
                  ->getUserService()

--- a/src/lib/ConfigResolver/ConfigurableRegistrationGroupLoader.php
+++ b/src/lib/ConfigResolver/ConfigurableRegistrationGroupLoader.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\User\ConfigResolver;
 
 use Ibexa\Contracts\Core\Repository\Repository;
+use Ibexa\Contracts\Core\Repository\Values\User\UserGroup;
 use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
 
 /**
@@ -31,7 +32,7 @@ class ConfigurableRegistrationGroupLoader implements RegistrationGroupLoader
     public function loadGroup()
     {
         if ($this->configResolver->hasParameter('user_registration.group_remote_id')) {
-            return $this->repository->sudo(function (Repository $repository) {
+            return $this->repository->sudo(function (Repository $repository): UserGroup {
                 return $repository
                     ->getUserService()
                     ->loadUserGroupByRemoteId(
@@ -40,7 +41,7 @@ class ConfigurableRegistrationGroupLoader implements RegistrationGroupLoader
             });
         }
 
-        return $this->repository->sudo(function (Repository $repository) {
+        return $this->repository->sudo(function (Repository $repository): UserGroup {
             return $repository
                  ->getUserService()
                  ->loadUserGroup(

--- a/src/lib/Form/Data/UserInvitationData.php
+++ b/src/lib/Form/Data/UserInvitationData.php
@@ -18,6 +18,7 @@ final class UserInvitationData
 {
     /**
      * @Assert\NotBlank()
+     *
      * @Assert\Email()
      */
     private string $email;

--- a/src/lib/Form/Data/UserPasswordChangeData.php
+++ b/src/lib/Form/Data/UserPasswordChangeData.php
@@ -15,6 +15,7 @@ class UserPasswordChangeData
 {
     /**
      * @UserAssert\UserPassword()
+     *
      * @Assert\NotBlank()
      *
      * @var string

--- a/tests/integration/SampleTest.php
+++ b/tests/integration/SampleTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Integration\User;
 
 /**
  * @group integration
+ *
  * @coversNothing
  */
 final class SampleTest extends IbexaKernelTestCase

--- a/tests/lib/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoaderTest.php
+++ b/tests/lib/Form/Type/ChoiceList/Loader/AvailableLocaleChoiceLoaderTest.php
@@ -64,7 +64,7 @@ class AvailableLocaleChoiceLoaderTest extends TestCase
             $availableTranslations
         );
 
-        $this->assertSame($expectedLocales, $availableLocaleChoiceLoader->getChoiceList());
+        self::assertSame($expectedLocales, $availableLocaleChoiceLoader->getChoiceList());
     }
 
     public function providerForGetChoiceList(): array

--- a/tests/lib/Invitation/InvitationServiceTest.php
+++ b/tests/lib/Invitation/InvitationServiceTest.php
@@ -27,10 +27,10 @@ class InvitationServiceTest extends TestCase
     private InvitationService $invitationService;
 
     /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private $siteAccessService;
+    private SiteAccessServiceInterface $siteAccessService;
 
     /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private $configResolver;
+    private ConfigResolverInterface $configResolver;
 
     protected function setUp(): void
     {

--- a/tests/lib/Invitation/InvitationServiceTest.php
+++ b/tests/lib/Invitation/InvitationServiceTest.php
@@ -26,6 +26,12 @@ class InvitationServiceTest extends TestCase
 {
     private InvitationService $invitationService;
 
+    /** @var \Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $siteAccessService;
+
+    /** @var \Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private $configResolver;
+
     protected function setUp(): void
     {
         $this->siteAccessService = $this->createMock(SiteAccessServiceInterface::class);
@@ -63,7 +69,7 @@ class InvitationServiceTest extends TestCase
                 $invitation->getSiteAccessIdentifier()
             )->willReturn('P2D');
 
-        $this->assertSame(
+        self::assertSame(
             $isValid,
             $this->invitationService->isValid($invitation)
         );

--- a/tests/lib/Permission/UserPermissionsLimitationTypeTest.php
+++ b/tests/lib/Permission/UserPermissionsLimitationTypeTest.php
@@ -151,7 +151,7 @@ class UserPermissionsLimitationTypeTest extends Base
                 ->method('loadRole')
                 ->withConsecutive([4, Role::STATUS_DEFINED], [8, Role::STATUS_DEFINED])
                 ->willReturnOnConsecutiveCalls(
-                    $this->throwException(new NotFoundException('Role', 4)),
+                    self::throwException(new NotFoundException('Role', 4)),
                     new Role()
                 );
 
@@ -165,7 +165,7 @@ class UserPermissionsLimitationTypeTest extends Base
                 ->method('loadContentInfo')
                 ->withConsecutive([14], [18])
                 ->willReturnOnConsecutiveCalls(
-                    $this->throwException(new NotFoundException('Role', 4)),
+                    self::throwException(new NotFoundException('Role', 4)),
                     new ContentInfo()
                 );
 

--- a/tests/lib/UserSetting/UserSettingServiceTest.php
+++ b/tests/lib/UserSetting/UserSettingServiceTest.php
@@ -25,7 +25,7 @@ class UserSettingServiceTest extends TestCase
         $valueRegistry->method('countValueDefinitions')->willReturn(2);
         $userSettingService = new UserSettingService($userPreferenceService, $valueRegistry);
 
-        $this->assertEquals(2, $userSettingService->countUserSettings());
+        self::assertEquals(2, $userSettingService->countUserSettings());
     }
 
     public function testLoadUserSettings(): void
@@ -65,7 +65,7 @@ class UserSettingServiceTest extends TestCase
                 'value' => '3',
             ]),
         ];
-        $this->assertEquals($expected, $settings);
+        self::assertEquals($expected, $settings);
     }
 
     /**

--- a/tests/lib/UserSetting/ValueDefinitionRegistryTest.php
+++ b/tests/lib/UserSetting/ValueDefinitionRegistryTest.php
@@ -24,7 +24,7 @@ class ValueDefinitionRegistryTest extends TestCase
 
         $registry = new ValueDefinitionRegistry($definitions);
 
-        $this->assertEquals($definitions, $registry->getValueDefinitions());
+        self::assertEquals($definitions, $registry->getValueDefinitions());
     }
 
     public function testAddValueDefinition()
@@ -34,7 +34,7 @@ class ValueDefinitionRegistryTest extends TestCase
         $registry = new ValueDefinitionRegistry([]);
         $registry->addValueDefinition('foo', $foo);
 
-        $this->assertEquals(['foo' => $foo], $registry->getValueDefinitions());
+        self::assertEquals(['foo' => $foo], $registry->getValueDefinitions());
     }
 
     public function testHasValueDefinition()
@@ -43,8 +43,8 @@ class ValueDefinitionRegistryTest extends TestCase
             'foo' => $this->createMock(ValueDefinitionInterface::class),
         ]);
 
-        $this->assertTrue($registry->hasValueDefinition('foo'));
-        $this->assertFalse($registry->hasValueDefinition('bar'));
+        self::assertTrue($registry->hasValueDefinition('foo'));
+        self::assertFalse($registry->hasValueDefinition('bar'));
     }
 
     public function testGetValueDefinition()
@@ -55,7 +55,7 @@ class ValueDefinitionRegistryTest extends TestCase
             'foo' => $foo,
         ]);
 
-        $this->assertEquals($foo, $registry->getValueDefinition('foo'));
+        self::assertEquals($foo, $registry->getValueDefinition('foo'));
     }
 
     public function testCountValueDefinitions()
@@ -67,14 +67,14 @@ class ValueDefinitionRegistryTest extends TestCase
 
         $registry = new ValueDefinitionRegistry($definitions);
 
-        $this->assertEquals(2, $registry->countValueDefinitions());
+        self::assertEquals(2, $registry->countValueDefinitions());
     }
 
     public function testCountValueDefinitionsWithEmptyRegistry()
     {
         $registry = new ValueDefinitionRegistry([]);
 
-        $this->assertEquals(0, $registry->countValueDefinitions());
+        self::assertEquals(0, $registry->countValueDefinitions());
     }
 }
 

--- a/tests/lib/Validator/Constraint/PasswordTest.php
+++ b/tests/lib/Validator/Constraint/PasswordTest.php
@@ -24,17 +24,17 @@ class PasswordTest extends TestCase
 
     public function testConstruct(): void
     {
-        $this->assertSame('ez.user.password.invalid', $this->constraint->message);
+        self::assertSame('ez.user.password.invalid', $this->constraint->message);
     }
 
     public function testValidatedBy(): void
     {
-        $this->assertSame(PasswordValidator::class, $this->constraint->validatedBy());
+        self::assertSame(PasswordValidator::class, $this->constraint->validatedBy());
     }
 
     public function testGetTargets(): void
     {
-        $this->assertSame([Password::CLASS_CONSTRAINT, Password::PROPERTY_CONSTRAINT], $this->constraint->getTargets());
+        self::assertSame([Password::CLASS_CONSTRAINT, Password::PROPERTY_CONSTRAINT], $this->constraint->getTargets());
     }
 }
 

--- a/tests/lib/Validator/Constraint/PasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraint/PasswordValidatorTest.php
@@ -44,11 +44,11 @@ class PasswordValidatorTest extends TestCase
     public function testValidateShouldBeSkipped($value): void
     {
         $this->userService
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('validatePassword');
 
         $this->executionContext
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('buildViolation');
 
         $this->validator->validate($value, new Password());
@@ -79,7 +79,7 @@ class PasswordValidatorTest extends TestCase
             );
 
         $this->executionContext
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('buildViolation');
 
         $this->validator->validate(
@@ -99,7 +99,7 @@ class PasswordValidatorTest extends TestCase
         $errorMessage = 'error';
 
         $this->userService
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('validatePassword')
             ->willReturnCallback(function (string $actualPassword, PasswordValidationContext $actualContext) use (
                 $password,
@@ -119,21 +119,21 @@ class PasswordValidatorTest extends TestCase
         $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
 
         $this->executionContext
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('buildViolation')
             ->willReturn($constraintViolationBuilder);
         $this->executionContext
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('buildViolation')
             ->with($errorMessage)
             ->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('setParameters')
             ->with(['%foo%' => $errorParameter])
             ->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('addViolation');
 
         $this->validator->validate('pass', new Password([

--- a/tests/lib/Validator/Constraint/UserPasswordValidatorTest.php
+++ b/tests/lib/Validator/Constraint/UserPasswordValidatorTest.php
@@ -58,13 +58,13 @@ class UserPasswordValidatorTest extends TestCase
     public function testEmptyValueType($value)
     {
         $this->userService
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('checkUserCredentials');
         $this->tokenStorage
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('getToken');
         $this->executionContext
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('buildViolation');
 
         $this->validator->validate($value, new UserPassword());
@@ -81,7 +81,7 @@ class UserPasswordValidatorTest extends TestCase
     public function testValid()
     {
         $apiUser = $this->getMockForAbstractClass(APIUser::class, [], '', true, true, true, ['__get']);
-        $apiUser->method('__get')->with($this->equalTo('login'))->willReturn('login');
+        $apiUser->method('__get')->with(self::equalTo('login'))->willReturn('login');
         $user = $this->createMock(ReferenceUserInterface::class);
         $user->method('getAPIUser')->willReturn($apiUser);
         $token = $this->createMock(TokenInterface::class);
@@ -92,7 +92,7 @@ class UserPasswordValidatorTest extends TestCase
             ->with($apiUser, 'password')
             ->willReturn(true);
         $this->executionContext
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('buildViolation');
 
         $this->validator->validate('password', new UserPassword());
@@ -101,7 +101,7 @@ class UserPasswordValidatorTest extends TestCase
     public function testInvalid()
     {
         $apiUser = $this->getMockForAbstractClass(APIUser::class, [], '', true, true, true, ['__get']);
-        $apiUser->method('__get')->with($this->equalTo('login'))->willReturn('login');
+        $apiUser->method('__get')->with(self::equalTo('login'))->willReturn('login');
         $user = $this->createMock(ReferenceUserInterface::class);
         $user->method('getAPIUser')->willReturn($apiUser);
         $token = $this->createMock(TokenInterface::class);
@@ -114,7 +114,7 @@ class UserPasswordValidatorTest extends TestCase
         $constraint = new UserPassword();
         $constraintViolationBuilder = $this->createMock(ConstraintViolationBuilderInterface::class);
         $this->executionContext
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('buildViolation')
             ->with($constraint->message)
             ->willReturn($constraintViolationBuilder);


### PR DESCRIPTION
| :ticket: Issue | IBX-8552 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/checkout/pull/213
- https://github.com/ibexa/recipes-dev/pull/165
- https://github.com/ibexa/storefront/pull/200
#### Description:

SonarCloud analysis is false positive and relates to change from `$this->assert` to `self::assert`

#### For QA:
This fix nothing out of the box in existing instalations - if wrong group is assigned (and it was by default), nothing we can do to fix it. However, this fix new instalations and adds possible configuration with remote content id so we avoid those problems in the future.
 
#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
