### PR TITLE
IBX-8552: Dropped deprecated group_id config key

### DIFF
--- a/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/UserRegistration.php
@@ -29,14 +29,9 @@ class UserRegistration extends AbstractParser
                         ->info('Content type identifier used for registration.')
                         ->defaultValue('user')
                     ->end()
-                    ->scalarNode('group_id')
-                        ->info('Content id of the user group where users who register are created.')
-                        ->defaultValue(11)
-                        ->setDeprecated('ibexa/user', '4.6', 'The child node "%node%" at path "%path%" is deprecated, use group_remote_id instead.')
-                    ->end()
                     ->scalarNode('group_remote_id')
-                        ->info('Content remote id of the user group where users who register are created - takes precedence over group_id if set.')
-                        ->defaultNull()
+                        ->info('Content remote id of the user group where users who register are created.')
+                        ->defaultValue('5f7f0bdb3381d6a461d8c29ff53d908f')
                     ->end()
                     ->arrayNode('templates')
                         ->info('User registration templates.')
@@ -75,14 +70,6 @@ class UserRegistration extends AbstractParser
                 'user_registration.user_type_identifier',
                 $currentScope,
                 $settings['user_type_identifier']
-            );
-        }
-
-        if (!empty($settings['group_id'])) {
-            $contextualizer->setContextualParameter(
-                'user_registration.group_id',
-                $currentScope,
-                $settings['group_id']
             );
         }
 

--- a/src/bundle/Resources/config/ibexa_core_default_settings.yaml
+++ b/src/bundle/Resources/config/ibexa_core_default_settings.yaml
@@ -12,7 +12,7 @@ parameters:
     ibexa.site_access.config.default.user_reset_password.templates.success: "@@IbexaUser/reset_password/success.html.twig"
 
     # Registration
-    ibexa.site_access.config.default.user_registration.group_id: 11
+    ibexa.site_access.config.default.user_registration.group_remote_id: '5f7f0bdb3381d6a461d8c29ff53d908f'
     ibexa.site_access.config.default.user_registration.user_type_identifier: 'user'
     ibexa.site_access.config.default.user_registration.templates.form: "@@IbexaContentForms/Content/content_edit.html.twig"
     ibexa.site_access.config.default.user_registration.templates.confirmation: "@@IbexaUser/register/register_confirmation.html.twig"

--- a/src/lib/ConfigResolver/ConfigurableRegistrationGroupLoader.php
+++ b/src/lib/ConfigResolver/ConfigurableRegistrationGroupLoader.php
@@ -31,22 +31,12 @@ class ConfigurableRegistrationGroupLoader implements RegistrationGroupLoader
 
     public function loadGroup()
     {
-        if ($this->configResolver->hasParameter('user_registration.group_remote_id')) {
-            return $this->repository->sudo(function (Repository $repository): UserGroup {
-                return $repository
-                    ->getUserService()
-                    ->loadUserGroupByRemoteId(
-                        $this->configResolver->getParameter('user_registration.group_remote_id')
-                    );
-            });
-        }
-
         return $this->repository->sudo(function (Repository $repository): UserGroup {
             return $repository
-                 ->getUserService()
-                 ->loadUserGroup(
-                     $this->configResolver->getParameter('user_registration.group_id')
-                 );
+                ->getUserService()
+                ->loadUserGroupByRemoteId(
+                    $this->configResolver->getParameter('user_registration.group_remote_id')
+                );
         });
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8552 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/user/pull/98

#### Description:
The remote ID used corresponds to the user group with ID 11, as defined in cleandata.sql. We could consider changing it to something more human-readable, but I’m not sure how that might affect update paths, if at all."

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
