### PR TITLE
Specified return type for `getTranslationMessages` methods.

### DIFF
--- a/src/lib/Permission/InvitationPolicyProvider.php
+++ b/src/lib/Permission/InvitationPolicyProvider.php
@@ -24,7 +24,7 @@ final class InvitationPolicyProvider implements PolicyProviderInterface, Transla
         ]);
     }
 
-    public static function getTranslationMessages()
+    public static function getTranslationMessages(): array
     {
         return [
             (new Message('role.policy.user', 'forms'))->setDesc('User'),

--- a/src/lib/Validator/Constraints/EmailInvitation.php
+++ b/src/lib/Validator/Constraints/EmailInvitation.php
@@ -19,7 +19,7 @@ class EmailInvitation extends Constraint implements TranslationContainerInterfac
 {
     public string $message = 'ibexa.user.invitation.user_with_email_exists';
 
-    public static function getTranslationMessages()
+    public static function getTranslationMessages(): array
     {
         return [
             Message::create('ibexa.user.invitation.user_with_email_exists', 'validators')


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|

#### Description:
To ensure compatibility with potential future changes in the `JMS\TranslationBundle\Translation\TranslationContainerInterface`, this PR adds the native return type `array` to the `getTranslationMessages()` method in the following classes:

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
