### PR TITLE
Adapted to deprecated `null` value for content structs in `BaseContentType`

### DIFF
--- a/src/bundle/Controller/UserRegisterController.php
+++ b/src/bundle/Controller/UserRegisterController.php
@@ -43,7 +43,11 @@ class UserRegisterController extends Controller
         $form = $this->createForm(
             UserRegisterType::class,
             $data,
-            ['languageCode' => $language, 'mainLanguageCode' => $language]
+            [
+                'languageCode' => $language,
+                'mainLanguageCode' => $language,
+                'struct' => $data,
+            ]
         );
 
         $form->handleRequest($request);


### PR DESCRIPTION
| :ticket: Issue | IBX-9727 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/content-forms/pull/95

#### Description:
Adapted to deprecations introduced via https://github.com/ibexa/content-forms/pull/70.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
