### PR TITLE
[UI][i18n] Extracted missing translations

### DIFF
--- a/src/bundle/Resources/translations/ibexa_repository_exceptions.en.xliff
+++ b/src/bundle/Resources/translations/ibexa_repository_exceptions.en.xliff
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="619a3446ec0941d3e7e64a1b63c2938925e9b56a" resname="limitationValues[%key%] =&gt; '%value%' does not exist in the backend">
+        <source><![CDATA[limitationValues[%key%] => '%value%' does not exist in the backend]]></source>
+        <target state="new"><![CDATA[limitationValues[%key%] => '%value%' does not exist in the backend]]></target>
+        <note>key: limitationValues[%key%] =&gt; '%value%' does not exist in the backend</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Description:

Extracted missing translations after ibexa/core#590 changes.
`TranslationTest` is missing on 4.6, so I'll add it as a follow-up after the release.