### PR TITLE
IBX-11664: Fixed correct filtering out of fields not specified in `user_registration.form.allowed_field_definitions_identifiers` config

### DIFF
--- a/src/lib/Form/Type/UserRegisterType.php
+++ b/src/lib/Form/Type/UserRegisterType.php
@@ -55,7 +55,7 @@ class UserRegisterType extends AbstractType
             ->addEventSubscriber(new UserFieldsSubscriber());
 
         $builder->get('fieldsData')->addEventListener(
-            FormEvents::PRE_SET_DATA,
+            FormEvents::POST_SET_DATA,
             function (FormEvent $event): void {
                 $allowedFieldsId = $this
                     ->configResolver

--- a/tests/integration/Form/Type/UserRegisterTypeTest.php
+++ b/tests/integration/Form/Type/UserRegisterTypeTest.php
@@ -20,7 +20,6 @@ final class UserRegisterTypeTest extends IbexaKernelTestCase
 {
     public function testAllowedFieldDefinitionsIdentifiers(): void
     {
-        // Arrange
         $expectedIdentifiers = ['last_name'];
         $data = self::prepareUserRegisterData();
         $language = 'eng-GB';
@@ -33,7 +32,6 @@ final class UserRegisterTypeTest extends IbexaKernelTestCase
         self::getContainer()->set(UserRegisterType::class, new UserRegisterType($configResolver));
         $formFactory = self::getServiceByClassName(FormFactoryInterface::class);
 
-        // Act
         $form = $formFactory->create(
             UserRegisterType::class,
             $data,
@@ -44,7 +42,6 @@ final class UserRegisterTypeTest extends IbexaKernelTestCase
             ]
         );
 
-        // Assert
         $fieldsData = $form->get('fieldsData');
         self::assertCount(count($expectedIdentifiers), $fieldsData);
         foreach ($expectedIdentifiers as $identifier) {

--- a/tests/integration/Form/Type/UserRegisterTypeTest.php
+++ b/tests/integration/Form/Type/UserRegisterTypeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\User\Form\Type;
+
+use Ibexa\Contracts\ContentForms\Data\Content\FieldData;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+use Ibexa\Core\Repository\Values\ContentType\FieldDefinition;
+use Ibexa\Tests\Integration\User\IbexaKernelTestCase;
+use Ibexa\User\Form\Data\UserRegisterData;
+use Ibexa\User\Form\Type\UserRegisterType;
+use Symfony\Component\Form\FormFactoryInterface;
+
+class UserRegisterTypeTest extends IbexaKernelTestCase
+{
+    public function testAllowedFieldDefinitionsIdentifiers(): void
+    {
+        // Arrange
+        $expectedIdentifiers = ['last_name'];
+        $data = self::prepareUserRegisterData();
+        $language = 'eng-GB';
+
+        $configResolver = $this->createMock(ConfigResolverInterface::class);
+        $configResolver
+            ->method('getParameter')
+            ->with('user_registration.form.allowed_field_definitions_identifiers')
+            ->willReturn($expectedIdentifiers);
+        self::getContainer()->set(UserRegisterType::class, new UserRegisterType($configResolver));
+        $formFactory = self::getServiceByClassName(FormFactoryInterface::class);
+
+        // Act
+        $form = $formFactory->create(
+            UserRegisterType::class,
+            $data,
+            [
+                'languageCode' => $language,
+                'mainLanguageCode' => $language,
+                'struct' => $data,
+            ]
+        );
+
+        // Assert
+        $fieldsData = $form->get('fieldsData');
+        self::assertCount(count($expectedIdentifiers), $fieldsData);
+        foreach ($expectedIdentifiers as $identifier) {
+            self::assertTrue(
+                $fieldsData->has($identifier),
+                sprintf('fieldsData is missing expected child "%s"', $identifier)
+            );
+        }
+    }
+
+    private static function prepareUserRegisterData(): UserRegisterData
+    {
+        return new UserRegisterData(['fieldsData' => [
+            'first_name' => new FieldData([
+                'fieldDefinition' => new FieldDefinition([
+                    'fieldTypeIdentifier' => '',
+                ]),
+            ]),
+            'last_name' => new FieldData([
+                'fieldDefinition' => new FieldDefinition([
+                    'fieldTypeIdentifier' => '',
+                ]),
+            ]),
+            'user_account' => new FieldData([
+                'fieldDefinition' => new FieldDefinition([
+                    'fieldTypeIdentifier' => '',
+                ]),
+            ]),
+        ]]);
+    }
+}

--- a/tests/integration/Form/Type/UserRegisterTypeTest.php
+++ b/tests/integration/Form/Type/UserRegisterTypeTest.php
@@ -16,7 +16,7 @@ use Ibexa\User\Form\Data\UserRegisterData;
 use Ibexa\User\Form\Type\UserRegisterType;
 use Symfony\Component\Form\FormFactoryInterface;
 
-class UserRegisterTypeTest extends IbexaKernelTestCase
+final class UserRegisterTypeTest extends IbexaKernelTestCase
 {
     public function testAllowedFieldDefinitionsIdentifiers(): void
     {

--- a/tests/integration/Form/Type/UserRegisterTypeTest.php
+++ b/tests/integration/Form/Type/UserRegisterTypeTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 namespace Ibexa\Tests\Integration\User\Form\Type;

--- a/tests/integration/IbexaTestKernel.php
+++ b/tests/integration/IbexaTestKernel.php
@@ -8,12 +8,14 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Integration\User;
 
+use Ibexa\Bundle\ContentForms\IbexaContentFormsBundle;
 use Ibexa\Bundle\Notifications\IbexaNotificationsBundle;
 use Ibexa\Bundle\User\IbexaUserBundle;
 use Ibexa\ContentForms\Form\ActionDispatcher\UserDispatcher;
 use Ibexa\Contracts\Core\Test\IbexaTestKernel as BaseIbexaTestKernel;
 use Ibexa\Contracts\User\Invitation\InvitationService;
 use LogicException;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -38,6 +40,7 @@ final class IbexaTestKernel extends BaseIbexaTestKernel
         yield from [
             new IbexaUserBundle(),
             new IbexaNotificationsBundle(),
+            new IbexaContentFormsBundle(),
         ];
     }
 
@@ -47,6 +50,7 @@ final class IbexaTestKernel extends BaseIbexaTestKernel
         yield from parent::getExposedServicesByClass();
 
         yield InvitationService::class;
+        yield FormFactoryInterface::class;
     }
 
     #[\Override]

--- a/tests/integration/IbexaTestKernel.php
+++ b/tests/integration/IbexaTestKernel.php
@@ -15,10 +15,10 @@ use Ibexa\ContentForms\Form\ActionDispatcher\UserDispatcher;
 use Ibexa\Contracts\Core\Test\IbexaTestKernel as BaseIbexaTestKernel;
 use Ibexa\Contracts\User\Invitation\InvitationService;
 use LogicException;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Form\FormFactoryInterface;
 
 final class IbexaTestKernel extends BaseIbexaTestKernel
 {


### PR DESCRIPTION
| :ticket: Issue | [IBX-11664](https://ibexa.atlassian.net/browse/IBX-11664) |
|----------------|-----------|

#### Description:
From SF `7.2` version [ResizeFormListener](https://github.com/symfony/symfony/blob/v7.2.0/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php#L52) added handling of `FormEvents::POST_SET_DATA`, so our filtering out of not defined fields in `user_registration.form.allowed_field_definitions_identifiers` didn't impact form because it was done before (on `FormEvents::POST_SET_DATA` event).

It looks like it was adjusted in [FieldCollectionType](https://github.com/ibexa/content-forms/blob/v5.0.0/src/lib/Form/Type/Content/FieldCollectionType.php#L45) in version `5.0.0`, but was missed here in [UserRegisterType](https://github.com/ibexa/user/blob/main/src/lib/Form/Type/UserRegisterType.php#L58).

#### For QA:
It worked in `4.6` version, however in `5.0` with Symfony `7.2` internal `\Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener` changed its behaviour, which impacted our feature and it stopped working.

#### Documentation:

[IBX-11664]: https://ibexa.atlassian.net/browse/IBX-11664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ