### PR TITLE
IBX-12043: Remove deprecated sequence-name argument from lastInsertId()

### DIFF
--- a/src/lib/Invitation/Persistence/DoctrineGateway.php
+++ b/src/lib/Invitation/Persistence/DoctrineGateway.php
@@ -25,8 +25,6 @@ final readonly class DoctrineGateway implements Gateway
     private const string TABLE_USER_INVITATIONS = 'ibexa_user_invitation';
     private const string TABLE_USER_INVITATIONS_ASSIGNMENTS = 'ibexa_user_invitation_assignment';
 
-    private const string TABLE_USER_INVITATIONS_SEQ = 'ibexa_user_invitation_id_seq';
-
     public function __construct(
         private Connection $connection
     ) {
@@ -55,7 +53,7 @@ final readonly class DoctrineGateway implements Gateway
             );
 
         $query->executeStatement();
-        $invitationId = $this->connection->lastInsertId(self::TABLE_USER_INVITATIONS_SEQ);
+        $invitationId = $this->connection->lastInsertId();
 
         $assigmentQuery = $this->connection->createQueryBuilder();
         $assigmentQuery


### PR DESCRIPTION
## Why

`Connection::lastInsertId($sequenceName)` is deprecated in DBAL 3.10 and removed in DBAL 4 (sequences aren't portable across drivers this way). Forward-compat cleanup ahead of the DBAL 4 bump — no behavior change.

## Changes

- `Invitation/Persistence/DoctrineGateway.php`: `lastInsertId(self::TABLE_USER_INVITATIONS_SEQ)` → `lastInsertId()`; removed the now-fully-unused `TABLE_USER_INVITATIONS_SEQ` constant.

## Test plan

- [x] `php -l` clean
- [x] Repo-wide grep confirms zero remaining `lastInsertId(` calls with an argument
- [x] `composer test` — 75 tests, 114 assertions, all passing