### PR TITLE
IBX-11774: Changed `location` into `locale` in user settings flash message

### DIFF
--- a/src/bundle/Controller/UserSettingsController.php
+++ b/src/bundle/Controller/UserSettingsController.php
@@ -102,6 +102,7 @@ class UserSettingsController extends Controller
                 $this->actionResultHandler->success(
                     /** @Desc("User settings '%identifier%' updated.") */
                     'user_setting.update.success',
+                    // To avoid breaking BC promise we are simply replacing flash message instead of redefining configuration
                     ['%identifier%' => $identifier === 'location' ? 'locale' : $identifier],
                     'ibexa_user_settings'
                 );

--- a/src/bundle/Controller/UserSettingsController.php
+++ b/src/bundle/Controller/UserSettingsController.php
@@ -97,10 +97,12 @@ class UserSettingsController extends Controller
                     $this->userSettingService->setUserSetting($identifier, (string)$value['value']);
                 }
 
+                $identifier = $data->getIdentifier();
+
                 $this->actionResultHandler->success(
                     /** @Desc("User settings '%identifier%' updated.") */
                     'user_setting.update.success',
-                    ['%identifier%' => $data->getIdentifier()],
+                    ['%identifier%' => $identifier === 'location' ? 'locale' : $identifier],
                     'ibexa_user_settings'
                 );
 


### PR DESCRIPTION
| :ticket: Issue | IBX-11774 |
|----------------|-----------|

#### Related PRs: 
https://github.com/ibexa/user/pull/124

#### Description:
The solution seems hacky, but a 'proper' solution is changing `location` identifier in different areas - services, route, maybe it does make sense to do it in `v6.0` but I'm not sure about `4.6` and `5.0` due to BC.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
